### PR TITLE
[FIX] Imports from inside folders were not resolving correctly

### DIFF
--- a/src/server/compiler/AppCompiler.ts
+++ b/src/server/compiler/AppCompiler.ts
@@ -152,8 +152,11 @@ export class AppCompiler {
                         return resolvedModules.push({ resolvedFileName: moduleName + '.js' });
                     }
 
+                    const currentFolderPath = path.dirname(containingFile).replace(cwd, '');
+                    const modulePath = path.join(currentFolderPath, moduleName);
+
                     // Let's ensure we search for the App's modules first
-                    const transformedModule = Utilities.transformModuleForCustomRequire(moduleName);
+                    const transformedModule = Utilities.transformModuleForCustomRequire(modulePath);
                     if (result.files[transformedModule]) {
                         return resolvedModules.push({ resolvedFileName: transformedModule });
                     }

--- a/src/server/misc/Utilities.ts
+++ b/src/server/misc/Utilities.ts
@@ -34,7 +34,7 @@ export class Utilities {
     }
 
     public static transformModuleForCustomRequire(moduleName: string): string {
-        return path.normalize(moduleName).replace(/\.\.\//g, '') + '.ts';
+        return path.normalize(moduleName).replace(/\.\.?\//g, '').replace(/^\//, '') + '.ts';
     }
 
     public static allowedInternalModuleRequire(moduleName: string): boolean {


### PR DESCRIPTION
When importing a file `a.ts` in a file `b.ts` from inside a folder `folder` was resolving to `a.ts` instead of `folder/a.ts` what was causing the compiler to not found the file since from compiler scope the base path is the root and not the path of the current file.