### PR TITLE
[FIX] Slash Command Contexts Not Supporting Usernames on Rooms

### DIFF
--- a/src/server/managers/AppSlashCommandManager.ts
+++ b/src/server/managers/AppSlashCommandManager.ts
@@ -320,19 +320,8 @@ export class AppSlashCommandManager {
             return;
         }
 
-        // Due to the internal changes for the usernames property, we need to ensure the room
-        // is a class and not just an interface
-        let room: Room;
-        if (context.getRoom() instanceof Room) {
-            room = context.getRoom() as Room;
-        } else {
-            room = new Room(context.getRoom(), this.manager);
-        }
-
-        const newContext = new SlashCommandContext(context.getSender(), room, context.getArguments());
-
         const appCmd = this.retrieveCommandInfo(cmd, app.getID());
-        await appCmd.runExecutorOrPreviewer(AppMethod._COMMAND_EXECUTOR, newContext, this.manager.getLogStorage(), this.accessors);
+        await appCmd.runExecutorOrPreviewer(AppMethod._COMMAND_EXECUTOR, this.ensureContext(context), this.manager.getLogStorage(), this.accessors);
 
         return;
     }
@@ -352,19 +341,10 @@ export class AppSlashCommandManager {
             return;
         }
 
-        // Due to the internal changes for the usernames property, we need to ensure the room
-        // is a class and not just an interface
-        let room: Room;
-        if (context.getRoom() instanceof Room) {
-            room = context.getRoom() as Room;
-        } else {
-            room = new Room(context.getRoom(), this.manager);
-        }
-
-        const newContext = new SlashCommandContext(context.getSender(), room, context.getArguments());
-
         const appCmd = this.retrieveCommandInfo(cmd, app.getID());
-        const result = await appCmd.runExecutorOrPreviewer(AppMethod._COMMAND_PREVIEWER, newContext, this.manager.getLogStorage(), this.accessors);
+
+        // tslint:disable-next-line:max-line-length
+        const result = await appCmd.runExecutorOrPreviewer(AppMethod._COMMAND_PREVIEWER, this.ensureContext(context), this.manager.getLogStorage(), this.accessors);
 
         if (!result) {
             // Failed to get the preview, thus returning is fine
@@ -389,6 +369,13 @@ export class AppSlashCommandManager {
             return;
         }
 
+        const appCmd = this.retrieveCommandInfo(cmd, app.getID());
+        await appCmd.runPreviewExecutor(previewItem, this.ensureContext(context), this.manager.getLogStorage(), this.accessors);
+
+        return;
+    }
+
+    private ensureContext(context: SlashCommandContext): SlashCommandContext {
         // Due to the internal changes for the usernames property, we need to ensure the room
         // is a class and not just an interface
         let room: Room;
@@ -398,12 +385,7 @@ export class AppSlashCommandManager {
             room = new Room(context.getRoom(), this.manager);
         }
 
-        const newContext = new SlashCommandContext(context.getSender(), room, context.getArguments());
-
-        const appCmd = this.retrieveCommandInfo(cmd, app.getID());
-        await appCmd.runPreviewExecutor(previewItem, newContext, this.manager.getLogStorage(), this.accessors);
-
-        return;
+        return new SlashCommandContext(context.getSender(), room, context.getArguments());
     }
 
     /**

--- a/src/server/managers/AppSlashCommandManager.ts
+++ b/src/server/managers/AppSlashCommandManager.ts
@@ -5,6 +5,7 @@ import { ISlashCommand, ISlashCommandPreview, ISlashCommandPreviewItem, SlashCom
 import { AppManager } from '../AppManager';
 import { IAppCommandBridge } from '../bridges';
 import { CommandAlreadyExistsError, CommandHasAlreadyBeenTouchedError } from '../errors';
+import { Room } from '../rooms/Room';
 import { AppAccessorManager } from './AppAccessorManager';
 import { AppSlashCommand } from './AppSlashCommand';
 
@@ -319,8 +320,19 @@ export class AppSlashCommandManager {
             return;
         }
 
+        // Due to the internal changes for the usernames property, we need to ensure the room
+        // is a class and not just an interface
+        let room: Room;
+        if (context.getRoom() instanceof Room) {
+            room = context.getRoom() as Room;
+        } else {
+            room = new Room(context.getRoom(), this.manager);
+        }
+
+        const newContext = new SlashCommandContext(context.getSender(), room, context.getArguments());
+
         const appCmd = this.retrieveCommandInfo(cmd, app.getID());
-        await appCmd.runExecutorOrPreviewer(AppMethod._COMMAND_EXECUTOR, context, this.manager.getLogStorage(), this.accessors);
+        await appCmd.runExecutorOrPreviewer(AppMethod._COMMAND_EXECUTOR, newContext, this.manager.getLogStorage(), this.accessors);
 
         return;
     }
@@ -340,8 +352,19 @@ export class AppSlashCommandManager {
             return;
         }
 
+        // Due to the internal changes for the usernames property, we need to ensure the room
+        // is a class and not just an interface
+        let room: Room;
+        if (context.getRoom() instanceof Room) {
+            room = context.getRoom() as Room;
+        } else {
+            room = new Room(context.getRoom(), this.manager);
+        }
+
+        const newContext = new SlashCommandContext(context.getSender(), room, context.getArguments());
+
         const appCmd = this.retrieveCommandInfo(cmd, app.getID());
-        const result = await appCmd.runExecutorOrPreviewer(AppMethod._COMMAND_PREVIEWER, context, this.manager.getLogStorage(), this.accessors);
+        const result = await appCmd.runExecutorOrPreviewer(AppMethod._COMMAND_PREVIEWER, newContext, this.manager.getLogStorage(), this.accessors);
 
         if (!result) {
             // Failed to get the preview, thus returning is fine
@@ -366,8 +389,19 @@ export class AppSlashCommandManager {
             return;
         }
 
+        // Due to the internal changes for the usernames property, we need to ensure the room
+        // is a class and not just an interface
+        let room: Room;
+        if (context.getRoom() instanceof Room) {
+            room = context.getRoom() as Room;
+        } else {
+            room = new Room(context.getRoom(), this.manager);
+        }
+
+        const newContext = new SlashCommandContext(context.getSender(), room, context.getArguments());
+
         const appCmd = this.retrieveCommandInfo(cmd, app.getID());
-        await appCmd.runPreviewExecutor(previewItem, context, this.manager.getLogStorage(), this.accessors);
+        await appCmd.runPreviewExecutor(previewItem, newContext, this.manager.getLogStorage(), this.accessors);
 
         return;
     }

--- a/tests/server/managers/AppSlashCommandManager.spec.ts
+++ b/tests/server/managers/AppSlashCommandManager.spec.ts
@@ -16,6 +16,7 @@ import { AppConsole } from '../../../src/server/logging';
 import { AppAccessorManager, AppApiManager, AppSlashCommandManager } from '../../../src/server/managers';
 import { AppSlashCommand } from '../../../src/server/managers/AppSlashCommand';
 import { ProxiedApp } from '../../../src/server/ProxiedApp';
+import { Room } from '../../../src/server/rooms/Room';
 import { AppLogStorage } from '../../../src/server/storage';
 
 export class AppSlashCommandManagerTestFixture {
@@ -341,6 +342,9 @@ export class AppSlashCommandManagerTestFixture {
         await Expect(async () => await ascm.executeCommand('not-registered', context)).not.toThrowAsync();
         await Expect(async () => await ascm.executeCommand('disabled-command', context)).not.toThrowAsync();
 
+        const classContext = new SlashCommandContext(TestData.getUser(), new Room(TestData.getRoom(), this.mockManager), []);
+        await Expect(async () => await ascm.executeCommand('it-exists', classContext)).not.toThrowAsync();
+
         // set it up for no "no app failure"
         const failedItems = new Map<string, AppSlashCommand>();
         const asm = new AppSlashCommand(this.mockApp, TestData.getSlashCommand('failure'));
@@ -354,7 +358,7 @@ export class AppSlashCommandManagerTestFixture {
         await Expect(async () => await ascm.executeCommand('command', context)).not.toThrowAsync();
         AppSlashCommandManagerTestFixture.doThrow = false;
 
-        Expect(this.mockApp.runInContext).toHaveBeenCalled().exactly(3);
+        Expect(this.mockApp.runInContext).toHaveBeenCalled().exactly(4);
     }
 
     @AsyncTest()
@@ -375,6 +379,9 @@ export class AppSlashCommandManagerTestFixture {
         await Expect(async () => await ascm.getPreviews('command', context)).not.toThrowAsync();
         await Expect(async () => await ascm.getPreviews('not-registered', context)).not.toThrowAsync();
         await Expect(async () => await ascm.getPreviews('disabled-command', context)).not.toThrowAsync();
+
+        const classContext = new SlashCommandContext(TestData.getUser(), new Room(TestData.getRoom(), this.mockManager), []);
+        await Expect(async () => await ascm.getPreviews('it-exists', classContext)).not.toThrowAsync();
 
         // set it up for no "no app failure"
         const failedItems = new Map<string, AppSlashCommand>();
@@ -407,6 +414,9 @@ export class AppSlashCommandManagerTestFixture {
         await Expect(async () => await ascm.executePreview('command', previewItem, context)).not.toThrowAsync();
         await Expect(async () => await ascm.executePreview('not-registered', previewItem, context)).not.toThrowAsync();
         await Expect(async () => await ascm.executePreview('disabled-command', previewItem, context)).not.toThrowAsync();
+
+        const classContext = new SlashCommandContext(TestData.getUser(), new Room(TestData.getRoom(), this.mockManager), []);
+        await Expect(async () => await ascm.executePreview('it-exists', previewItem, classContext)).not.toThrowAsync();
 
         // set it up for no "no app failure"
         const failedItems = new Map<string, AppSlashCommand>();


### PR DESCRIPTION
The usernames property of the rooms on the slash command contexts was not updated to the new style of code, classes, which allows getting the usernames of the users in the rooms.