### PR TITLE
Remove modifier and persistence accessors from AppAccessors

### DIFF
--- a/src/definition/accessors/IAppAccessors.ts
+++ b/src/definition/accessors/IAppAccessors.ts
@@ -1,12 +1,9 @@
-import { IEnvironmentRead, IHttp, IModify, IRead } from '../../definition/accessors';
+import { IEnvironmentRead, IHttp, IRead } from '../../definition/accessors';
 import { IApiEndpointMetadata } from '../api';
-import { IPersistence } from './IPersistence';
 
 export interface IAppAccessors {
     readonly environmentReader: IEnvironmentRead;
     readonly reader: IRead;
     readonly http: IHttp;
-    readonly modifier: IModify;
-    readonly persistence: IPersistence;
     readonly providedApiEndpoints: Array<IApiEndpointMetadata>;
 }

--- a/src/server/accessors/AppAccessors.ts
+++ b/src/server/accessors/AppAccessors.ts
@@ -1,4 +1,4 @@
-import { IAppAccessors, IEnvironmentRead, IHttp, IModify, IPersistence, IRead } from '../../definition/accessors';
+import { IAppAccessors, IEnvironmentRead, IHttp, IRead } from '../../definition/accessors';
 import { IApiEndpointMetadata } from '../../definition/api';
 import { AppManager } from '../AppManager';
 import { AppAccessorManager } from '../managers/AppAccessorManager';

--- a/src/server/accessors/AppAccessors.ts
+++ b/src/server/accessors/AppAccessors.ts
@@ -25,14 +25,6 @@ export class AppAccessors implements IAppAccessors {
         return this.accessorManager.getHttp(this.appId);
     }
 
-    public get modifier(): IModify {
-        return this.accessorManager.getModifier(this.appId);
-    }
-
-    public get persistence(): IPersistence {
-        return this.accessorManager.getPersistence(this.appId);
-    }
-
     public get providedApiEndpoints(): Array<IApiEndpointMetadata> {
         return this.apiManager.listApis(this.appId);
     }

--- a/tests/server/accessors/AppAccessors.spec.ts
+++ b/tests/server/accessors/AppAccessors.spec.ts
@@ -103,8 +103,6 @@ export class AppAccessorsTestFixture {
         Expect(appAccessors.environmentReader).toEqual(this.mockAccessors.getEnvironmentRead('testing'));
         Expect(appAccessors.reader).toEqual(this.mockAccessors.getReader('testing'));
         Expect(appAccessors.http).toEqual(this.mockAccessors.getHttp('testing'));
-        Expect(appAccessors.modifier).toEqual(this.mockAccessors.getModifier('testing'));
-        Expect(appAccessors.persistence).toEqual(this.mockAccessors.getPersistence('testing'));
         Expect(appAccessors.providedApiEndpoints).toEqual(this.mockApiManager.listApis('testing'));
 
         this.mockApiManager.addApi('testing', TestData.getApi('app-accessor-api'));


### PR DESCRIPTION
Due to the realisation that access to IModify and IPersistence in the app's lifecycle methods, such as `initialize`, could lead to unintentional repeated runs on Rocket.Chat servers running more than one instance, we're removing those properties from AppAccessors