### PR TITLE
Add msg_processing_type field to message action

### DIFF
--- a/src/definition/messages/IMessageAction.ts
+++ b/src/definition/messages/IMessageAction.ts
@@ -1,4 +1,5 @@
 import { MessageActionType } from './MessageActionType';
+import { MessageProcessingType } from './MessageProcessingType';
 
 /**
  * Interface which represents an action which can be added to a message.
@@ -12,4 +13,5 @@ export interface IMessageAction {
     webview_height_ratio?: string;
     msg?: string;
     msg_in_chat_window?: boolean;
+    msg_processing_type?: MessageProcessingType;
 }

--- a/src/definition/messages/MessageProcessingType.ts
+++ b/src/definition/messages/MessageProcessingType.ts
@@ -1,0 +1,4 @@
+export enum MessageProcessingType {
+    SendMessage = 'sendMessage',
+    RespondWithMessage = 'respondWithMessage',
+}

--- a/src/definition/messages/index.ts
+++ b/src/definition/messages/index.ts
@@ -17,6 +17,7 @@ import { IPreMessageUpdatedModify } from './IPreMessageUpdatedModify';
 import { IPreMessageUpdatedPrevent } from './IPreMessageUpdatedPrevent';
 import { MessageActionButtonsAlignment } from './MessageActionButtonsAlignment';
 import { MessageActionType } from './MessageActionType';
+import { MessageProcessingType } from './MessageProcessingType';
 
 export {
     IMessage,
@@ -39,4 +40,5 @@ export {
     IPreMessageUpdatedPrevent,
     MessageActionButtonsAlignment,
     MessageActionType,
+    MessageProcessingType,
 };


### PR DESCRIPTION
Adds the field introduced in [this PR](https://github.com/RocketChat/Rocket.Chat/pull/12626) to the engine.

No further changes are needed on Rocket.Chat for it to work.