### PR TITLE
Modifies the version regex to reflect marketplace's requirements

### DIFF
--- a/src/definition/app-schema.json
+++ b/src/definition/app-schema.json
@@ -24,7 +24,7 @@
         "version": {
             "description": "The version of this App which will be used for display publicly and letting users know there is an update. This uses the semver format.",
             "type": "string",
-            "pattern": "\\bv?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?(?:\\+[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?\\b",
+            "pattern": "^(?:\\d*)\\.(?:\\d*)\\.(?:\\d*)$",
             "minLength": 5
         },
         "description": {
@@ -34,7 +34,7 @@
         "requiredApiVersion": {
             "description": "The required version of the App's API which this App depends on. This uses the semver format.",
             "type": "string",
-            "pattern": "\\bv?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?(?:\\+[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?\\b",
+            "pattern": "^(?:\\^|~)?(?:\\d*)\\.(?:\\d*)\\.(?:\\d*)$",
             "minLength": 5
         },
         "author": {


### PR DESCRIPTION
Uncomplicates the version regex in the `app-schema.json` file. There might be other places where the version regex is applied, but I wanted to get this one in there since it was my reference for the marketplace.