### PR TITLE
Reintroduce Bundle Installation

### DIFF
--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.6.0",
+  "version": "1.8.0",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -1,5 +1,5 @@
 import { AppBridges } from './bridges';
-import { AppCompiler, AppFabricationFulfillment, AppPackageParser } from './compiler';
+import { AppCompiler, AppFabricationFulfillment, AppPackageParser, IParseAppZipResult, IParseBundleZipResult, ZipContentType } from './compiler';
 import { IGetAppsFilter } from './IGetAppsFilter';
 import {
     AppAccessorManager,
@@ -155,14 +155,20 @@ export class AppManager {
             const aff = new AppFabricationFulfillment();
 
             try {
-                const result = await this.getParser().parseZip(this.getCompiler(), item.zip);
+                const zipResult = await this.getParser().parseZip(this.getCompiler(), Buffer.from(item.zip, 'base64'));
+
+                if (zipResult.contentType !== ZipContentType.APP) {
+                    throw new Error('Invalid zip content provided');
+                }
+
+                const result = zipResult.parsed as IParseAppZipResult;
 
                 aff.setAppInfo(result.info);
                 aff.setImplementedInterfaces(result.implemented.getValues());
                 aff.setCompilerErrors(result.compilerErrors);
 
                 if (result.compilerErrors.length > 0) {
-                    const errors = result.compilerErrors.map(({ message }) => message).join('\n');
+                    const errors = result.compilerErrors.map(({ message }: { message: string }) => message).join('\n');
 
                     throw new Error(`Failed to compile due to ${ result.compilerErrors.length } errors:\n${ errors }`);
                 }
@@ -371,27 +377,43 @@ export class AppManager {
         return true;
     }
 
-    public async add(zipContentsBase64d: string, enable = true, marketplaceInfo?: IMarketplaceInfo): Promise<AppFabricationFulfillment> {
+    public async add(zipContentsBase64d: string, enable = true, marketplaceInfo?: IMarketplaceInfo): Promise<Array<AppFabricationFulfillment>> {
+        const parseResult = await this.getParser().parseZip(this.getCompiler(), Buffer.from(zipContentsBase64d, 'base64'));
+
+        if (parseResult.contentType === ZipContentType.APP) {
+            return [await this.addApp(parseResult.parsed as IParseAppZipResult, enable, marketplaceInfo)];
+        }
+
+        if (parseResult.contentType === ZipContentType.BUNDLE) {
+            return this.addBundle(parseResult.parsed as IParseBundleZipResult, enable);
+        }
+    }
+
+    private addBundle(bundleParseResult: IParseBundleZipResult, enable: boolean): Promise<Array<AppFabricationFulfillment>> {
+        return Promise.all(bundleParseResult.apps.map(({ parseResult, license }) => this.addApp(parseResult, enable)));
+    }
+
+    private async addApp(parseResult: IParseAppZipResult, enable: boolean, marketplaceInfo?: IMarketplaceInfo) {
         const aff = new AppFabricationFulfillment();
-        const result = await this.getParser().parseZip(this.getCompiler(), zipContentsBase64d);
 
-        aff.setAppInfo(result.info);
-        aff.setImplementedInterfaces(result.implemented.getValues());
-        aff.setCompilerErrors(result.compilerErrors);
+        aff.setAppInfo(parseResult.info);
+        aff.setCompilerErrors(parseResult.compilerErrors);
 
-        if (result.compilerErrors.length > 0) {
+        if (parseResult.compilerErrors.length > 0) {
             return aff;
         }
 
+        aff.setImplementedInterfaces(parseResult.implemented.getValues());
+
         const created = await this.storage.create({
-            id: result.info.id,
-            info: result.info,
+            id: parseResult.info.id,
+            info: parseResult.info,
             status: AppStatus.UNKNOWN,
-            zip: zipContentsBase64d,
-            compiled: result.compiledFiles,
-            languageContent: result.languageContent,
+            zip: parseResult.zipContentsBase64d,
+            compiled: parseResult.compiledFiles,
+            languageContent: parseResult.languageContent,
             settings: {},
-            implemented: result.implemented.getValues(),
+            implemented: parseResult.implemented.getValues(),
             marketplaceInfo,
         });
 
@@ -450,7 +472,13 @@ export class AppManager {
 
     public async update(zipContentsBase64d: string): Promise<AppFabricationFulfillment> {
         const aff = new AppFabricationFulfillment();
-        const result = await this.getParser().parseZip(this.getCompiler(), zipContentsBase64d);
+        const zipResult = await this.getParser().parseZip(this.getCompiler(), Buffer.from(zipContentsBase64d, 'base64'));
+
+        if (zipResult.contentType !== ZipContentType.APP) {
+            throw new Error('Invalid zip content provided');
+        }
+
+        const result = zipResult.parsed as IParseAppZipResult;
 
         aff.setAppInfo(result.info);
         aff.setImplementedInterfaces(result.implemented.getValues());

--- a/src/server/compiler/AppCompiler.ts
+++ b/src/server/compiler/AppCompiler.ts
@@ -277,7 +277,7 @@ export class AppCompiler {
                 character,
                 message: `${dia.file.fileName} (${line + 1},${character + 1}): ${msg}`,
             });
-        });
+       });
 
         Object.keys(result.files).forEach((key) => {
             const file: ICompilerFile = result.files[key];

--- a/src/server/compiler/IBundleManifest.ts
+++ b/src/server/compiler/IBundleManifest.ts
@@ -1,0 +1,9 @@
+export interface IBundleManifest {
+    version: number;
+    workspaceId: string;
+    apps: Array<{
+        appId: string;
+        license: string;
+        filename: string;
+    }>;
+}

--- a/src/server/compiler/IParseAppZipResult.ts
+++ b/src/server/compiler/IParseAppZipResult.ts
@@ -1,0 +1,12 @@
+import { IAppInfo } from '../../definition/metadata';
+import { AppImplements } from './AppImplements';
+import { ICompilerError } from './ICompilerError';
+
+export interface IParseAppZipResult {
+    info: IAppInfo;
+    compiledFiles: { [key: string]: string };
+    languageContent: { [key: string]: object };
+    compilerErrors: Array<ICompilerError>;
+    zipContentsBase64d: string;
+    implemented?: AppImplements;
+}

--- a/src/server/compiler/IParseBundleZipResult.ts
+++ b/src/server/compiler/IParseBundleZipResult.ts
@@ -1,0 +1,14 @@
+import { IParseAppZipResult } from './IParseAppZipResult';
+
+export interface IBundleZipAppEntry {
+    appId: string;
+    license: string;
+    parseResult?: IParseAppZipResult;
+    error?: string;
+}
+
+export interface IParseBundleZipResult {
+    version: number;
+    workspaceId: string;
+    apps: Array<IBundleZipAppEntry>;
+}

--- a/src/server/compiler/IParseZipResult.ts
+++ b/src/server/compiler/IParseZipResult.ts
@@ -1,11 +1,12 @@
-import { IAppInfo } from '../../definition/metadata';
-import { AppImplements } from './AppImplements';
-import { ICompilerError } from './ICompilerError';
+import { IParseAppZipResult } from './IParseAppZipResult';
+import { IParseBundleZipResult } from './IParseBundleZipResult';
+
+export enum ZipContentType {
+    APP = 'app',
+    BUNDLE = 'bundle',
+}
 
 export interface IParseZipResult {
-    info: IAppInfo;
-    compiledFiles: { [key: string]: string };
-    languageContent: { [key: string]: object };
-    implemented: AppImplements;
-    compilerErrors: Array<ICompilerError>;
+    contentType: ZipContentType;
+    parsed: IParseAppZipResult | IParseBundleZipResult;
 }

--- a/src/server/compiler/InstallZipType.ts
+++ b/src/server/compiler/InstallZipType.ts
@@ -1,0 +1,4 @@
+export enum InstallZipType {
+    BUNDLE = 'BUNDLE',
+    APP = 'APP',
+}

--- a/src/server/compiler/index.ts
+++ b/src/server/compiler/index.ts
@@ -5,7 +5,9 @@ import { AppPackageParser } from './AppPackageParser';
 import { ICompilerError } from './ICompilerError';
 import { ICompilerFile } from './ICompilerFile';
 import { ICompilerResult } from './ICompilerResult';
-import { IParseZipResult } from './IParseZipResult';
+import { IParseAppZipResult } from './IParseAppZipResult';
+import { IBundleZipAppEntry, IParseBundleZipResult } from './IParseBundleZipResult';
+import { IParseZipResult, ZipContentType } from './IParseZipResult';
 
 export {
     AppCompiler,
@@ -16,5 +18,9 @@ export {
     ICompilerFile,
     ICompilerError,
     ICompilerResult,
+    IParseAppZipResult,
+    IParseBundleZipResult,
     IParseZipResult,
+    IBundleZipAppEntry,
+    ZipContentType,
 };

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,8 @@
     "max-line-length": [true, {
         "limit": 160,
         "ignore-pattern": "^import | *export .*? {"
-    }]
+    }],
+    "member-ordering": false
   },
   "jsRules": {
     "quotemark": [true, "single"]


### PR DESCRIPTION
# What? :boat:
Reintroduces Bundle Installation support for the engine
<!--
- Added x;
- Updated y;
- Removed z.
-->

# Why? :thinking:
Due to impairment with the Rocket.Chat release cycle, the Bundle Installation logic (that included a breaking change for the app installation API)  had to be removed from the package. This PR reintroduces that behavior
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes: