### PR TITLE
Ensure App has a user during update routine

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -505,6 +505,18 @@ export class AppManager {
         // the App instance from the source.
         const app = this.getCompiler().toSandBox(this, stored);
 
+        // Ensure there is an user for the app
+        try {
+            await this.ensureAppUser(app);
+        } catch (err) {
+            aff.setAppUserError({
+                username: app.getInfo().nameSlug,
+                message: 'Failed to create an app user for this app.',
+            });
+
+            return aff;
+        }
+
         // Store it temporarily so we can access it else where
         this.apps.set(app.getID(), app);
         aff.setApp(app);
@@ -810,5 +822,15 @@ export class AppManager {
         }
 
         return this.bridges.getUserBridge().remove(appUser, app.getID());
+    }
+
+    private async ensureAppUser(app: ProxiedApp): Promise<boolean> {
+        const appUser = await this.bridges.getUserBridge().getAppUser(app.getID());
+
+        if (appUser) {
+            return true;
+        }
+
+        return !!this.createAppUser(app);
     }
 }

--- a/src/server/bridges/IUserBridge.ts
+++ b/src/server/bridges/IUserBridge.ts
@@ -5,7 +5,7 @@ export interface IUserBridge {
 
     getByUsername(username: string, appId: string): Promise<IUser>;
 
-    getAppUser(appId: string): Promise<IUser>;
+    getAppUser(appId: string): Promise<IUser | undefined>;
 
     /**
      * Creates a user.


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Ensure Apps have users during update routine

# Why? :thinking:
Apps installed on Rocket.Chat before the engine started giving them a user upon installation should be given a user after update, without which the App wouldn't be able to use the latest functionality
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
