### PR TITLE
[FIX] Revert breaking changes on IUser definition

### DIFF
--- a/src/definition/users/IUser.ts
+++ b/src/definition/users/IUser.ts
@@ -5,17 +5,16 @@ import { UserType } from './UserType';
 export interface IUser {
     id: string;
     username: string;
+    emails: Array<IUserEmail>;
+    type: UserType;
+    isEnabled: boolean;
     name: string;
     roles: Array<string>;
-    type: UserType;
     status: string;
     statusConnection: UserStatusConnection;
-    isEnabled: boolean;
-    emails?: Array<IUserEmail>;
-    utcOffset?: number;
-    createdAt?: Date;
-    updatedAt?: Date;
-    lastLoginAt?: Date;
-    // For app user
+    utcOffset: number;
+    createdAt: Date;
+    updatedAt: Date;
+    lastLoginAt: Date;
     appId?: string;
 }

--- a/tests/server/accessors/ModifyCreator.spec.ts
+++ b/tests/server/accessors/ModifyCreator.spec.ts
@@ -27,6 +27,11 @@ export class ModifyCreatorTestFixture {
             statusConnection: UserStatusConnection.UNDEFINED,
             type: UserType.APP,
             username: 'mockAppUser',
+            emails: [],
+            utcOffset: -5,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            lastLoginAt: new Date(),
         };
 
         this.mockRoomBridge = {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
We messed up the IUser definition while finishing app user feature. This PR tries to revert all changes on it and only add an optional `appId` property on it.

# Why? :thinking:
<!--Additional explanation if needed-->
Avoid breaking changes and we already achieved the goal with `Partical<IUser>`.
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
N/A
# PS :eyes:
N/A