### PR TITLE
Introduce the `isOnlineAsync` method and deprecate `isOnline` on `LivechatRead`

### DIFF
--- a/src/server/accessors/LivechatRead.ts
+++ b/src/server/accessors/LivechatRead.ts
@@ -6,8 +6,18 @@ import { ILivechatBridge } from '../bridges/ILivechatBridge';
 export class LivechatRead implements ILivechatRead {
     constructor(private readonly livechatBridge: ILivechatBridge, private readonly appId: string) { }
 
+    /**
+     * @deprecated prefer the `isOnlineAsync` method.
+     * In the next major, this method will be `async`
+     */
     public isOnline(departmentId?: string): boolean {
+        console.warn('The `LivechatRead.isOnline` method is deprecated and won\'t behave as intended. Please use `LivechatRead.isOnlineAsync` instead');
+
         return this.livechatBridge.isOnline(departmentId);
+    }
+
+    public isOnlineAsync(departmentId?: string): Promise<boolean> {
+        return this.livechatBridge.isOnlineAsync(departmentId);
     }
 
     public getLivechatRooms(visitor: IVisitor, departmentId?: string): Promise<Array<ILivechatRoom>> {

--- a/src/server/accessors/LivechatRead.ts
+++ b/src/server/accessors/LivechatRead.ts
@@ -7,7 +7,7 @@ export class LivechatRead implements ILivechatRead {
     constructor(private readonly livechatBridge: ILivechatBridge, private readonly appId: string) { }
 
     /**
-     * @deprecated prefer the `isOnlineAsync` method.
+     * @deprecated please use the `isOnlineAsync` method instead.
      * In the next major, this method will be `async`
      */
     public isOnline(departmentId?: string): boolean {

--- a/src/server/bridges/ILivechatBridge.ts
+++ b/src/server/bridges/ILivechatBridge.ts
@@ -2,7 +2,12 @@ import { IDepartment, ILivechatMessage, ILivechatRoom, ILivechatTransferData, IV
 import { IUser } from '../../definition/users';
 
 export interface ILivechatBridge {
+    /**
+     * @deprecated please use the `isOnlineAsync` method instead.
+     * In the next major, this method will be `async`
+     */
     isOnline(departmentId?: string): boolean;
+    isOnlineAsync(departmentId?: string): Promise<boolean>;
     createMessage(message: ILivechatMessage, appId: string): Promise<string>;
     getMessageById(messageId: string, appId: string): Promise<ILivechatMessage>;
     updateMessage(message: ILivechatMessage, appId: string): Promise<void>;

--- a/tests/test-data/bridges/livechatBridge.ts
+++ b/tests/test-data/bridges/livechatBridge.ts
@@ -6,6 +6,9 @@ export class TestLivechatBridge implements ILivechatBridge {
     public isOnline(departmentId?: string): boolean {
         throw new Error('Method not implemented');
     }
+    public isOnlineAsync(departmentId?: string): Promise<boolean> {
+        throw new Error('Method not implemented');
+    }
     public createMessage(message: ILivechatMessage, appId: string): Promise<string> {
         throw new Error('Method not implemented');
     }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Introduce the new method `isOnlineAsync` method on the `LivechatRead` accessor and deprecate `isOnline`
# Why? :thinking:
<!--Additional explanation if needed-->
The `isOnline` method was lacking an asynchronous signature, which was causing execution problems. In order to avoid a breaking change on the API, we've decided to introduce a new method and deprecate the current one.
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
