### PR TITLE
Enable Apps to create rooms without assigning a creator manually

### DIFF
--- a/src/server/accessors/ModifyCreator.ts
+++ b/src/server/accessors/ModifyCreator.ts
@@ -96,7 +96,7 @@ export class ModifyCreator implements IModifyCreator {
         return this.bridges.getLivechatBridge().createMessage(result, this.appId);
     }
 
-    private _finishRoom(builder: IRoomBuilder): Promise<string> {
+    private async _finishRoom(builder: IRoomBuilder): Promise<string> {
         const result = builder.getRoom();
         delete result.id;
 
@@ -106,7 +106,13 @@ export class ModifyCreator implements IModifyCreator {
 
         if (result.type !== RoomType.LIVE_CHAT) {
             if (!result.creator || !result.creator.id) {
-                throw new Error('Invalid creator assigned to the room.');
+                const appUser = await this.bridges.getUserBridge().getAppUser(this.appId);
+
+                if (!appUser) {
+                    throw new Error('Invalid creator assigned to the message.');
+                }
+
+                result.creator = appUser;
             }
         }
 

--- a/tests/server/accessors/ModifyCreator.spec.ts
+++ b/tests/server/accessors/ModifyCreator.spec.ts
@@ -101,7 +101,7 @@ export class ModifyCreatorTestFixture {
         roomBd.setType(RoomType.CHANNEL);
         Expect(room.type).toBe(RoomType.CHANNEL);
 
-        await Expect(async () => await mc.finish(roomBd)).toThrowErrorAsync(Error, 'Invalid creator assigned to the room.');
+        await Expect(async () => await mc.finish(roomBd)).not.toThrowErrorAsync(Error, 'Invalid creator assigned to the room.');
         roomBd.setCreator(TestData.getUser());
         Expect(room.creator).toBeDefined();
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Currently, when an app wants to create a room, it is required that it provides a user to be assigned as the room creator.
This PR removes such requirement, assigning the app's default user if no other user has been provided for room creation.

# Why? :thinking:
<!--Additional explanation if needed-->
Removing barriers to getting things done usually improves developer experience :)

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
