### PR TITLE
[NEW] File upload validation proposal

### DIFF
--- a/src/definition/messages/IPreFileUploadAllow.ts
+++ b/src/definition/messages/IPreFileUploadAllow.ts
@@ -1,0 +1,28 @@
+import { IHttp, IPersistence, IRead } from '../accessors';
+import { IMessage } from './IMessage';
+
+/**  Handler which is called to determine whether a user is allowed to send a message or not. */
+export interface IPreFileUploadAllow {
+    /**
+     * Enables the handler to signal to the Apps framework whether
+     * this handler should actually be executed for the message
+     * about to be sent.
+     *
+     * @param message The message which is being sent
+     * @param read An accessor to the environment
+     * @param http An accessor to the outside world
+     * @returns whether to run the prevent or not
+     */
+    checkPreFileUploadAllow?(message: IMessage, read: IRead, http: IHttp): Promise<boolean>;
+
+    /**
+     * Method which is to be used to prevent a message from being sent.
+     *
+     * @param message The message about to be sent
+     * @param read An accessor to the environment
+     * @param http An accessor to the outside world
+     * @param persistence An accessor to the App's persistence storage
+     * @returns whether to prevent the message from being sent
+     */
+    executePreFileUploadAllow(message: IMessage, read: IRead, http: IHttp, persistence: IPersistence): Promise<boolean>;
+}

--- a/src/definition/messages/index.ts
+++ b/src/definition/messages/index.ts
@@ -19,6 +19,7 @@ import { IPreMessageUpdatedPrevent } from './IPreMessageUpdatedPrevent';
 import { MessageActionButtonsAlignment } from './MessageActionButtonsAlignment';
 import { MessageActionType } from './MessageActionType';
 import { MessageProcessingType } from './MessageProcessingType';
+export * from './IPreFileUploadAllow';
 
 export {
     IMessage,

--- a/src/definition/metadata/AppMethod.ts
+++ b/src/definition/metadata/AppMethod.ts
@@ -47,6 +47,11 @@ export enum AppMethod {
     UIKIT_BLOCK_ACTION = 'executeBlockActionHandler',
     UIKIT_VIEW_SUBMIT = 'executeViewSubmitHandler',
     UIKIT_VIEW_CLOSE = 'executeViewClosedHandler',
+
+    // File Upload
+    CHECK_PRE_FILEUPLOAD_ALLOW = 'checkPreFileUploadAllow',
+    EXECUTE_PRE_FILEUPLOAD_ALLOW = 'executePreFileUploadAllow',
+
     // Livechat
     EXECUTE_LIVECHAT_ROOM_CLOSED_HANDLER = 'executeLivechatRoomClosedHandler',
 }

--- a/src/server/compiler/AppImplements.ts
+++ b/src/server/compiler/AppImplements.ts
@@ -19,6 +19,9 @@ export enum AppInterface {
     IPostRoomCreate = 'IPostRoomCreate',
     IPreRoomDeletePrevent = 'IPreRoomDeletePrevent',
     IPostRoomDeleted = 'IPostRoomDeleted',
+    // Upload
+    IPreFileUploadAllow = 'IPreFileUploadAllow',
+    IPreFileUploadModify = 'IPreFileUploadModify',
     // Blocks
     IUIKitInteractionHandler = 'IUIKitInteractionHandler',
     // Livechat


### PR DESCRIPTION
# What? :boat:

Added `IPreFileUploadAllow` that allows the rockectchat apps to allow the file validation....

the apps can validate extension, headers, find for virus or any kind of content analysis 

# Why? :thinking:
Mime types validation or content validation is a hard thing to do only with one library one single test...

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

here an example how to validate a keynote file: 
```javascript
import { Buffer } from 'buffer';
import {
    IAppAccessors,
    ILogger,
} from '@rocket.chat/apps-engine/definition/accessors';
import { App } from '@rocket.chat/apps-engine/definition/App';
import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
import { IPreFileUploadAllow } from '@rocket.chat/apps-engine/definition/messages';

export class ImageFilesApp extends App implements IPreFileUploadAllow {
    constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
        super(info, logger, accessors);
    }

    public async executePreFileUploadAllow({ file, stream: buffer }: any) {
        const KEYNOTE_HEADER = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14]);

        if (/\.(key|numbers|pages)$/.test(file.name) && buffer.compare(KEYNOTE_HEADER, 0, 5)){
            return false;
        }

        return true;
    }
}
```


# PS :eyes:

❤️ 


# PS 2

Still missing:

- [ ]  few comments adjust, and I would love introduce a way to modify the file
- [ ] create data definition (buffer and stream)