### PR TITLE
Add field `uids` to rooms

### DIFF
--- a/src/definition/accessors/IRoomBuilder.ts
+++ b/src/definition/accessors/IRoomBuilder.ts
@@ -174,6 +174,11 @@ export interface IRoomBuilder {
     getCustomFields(): { [key: string]: object };
 
     /**
+     * Gets user ids of members from a direct message
+     */
+    getUserIds(): Array<string>;
+
+    /**
      * Gets the resulting room that has been built up to the point of calling this method.
      * Note: modifying the returned value will have no effect.
      */

--- a/src/definition/rooms/IRoom.ts
+++ b/src/definition/rooms/IRoom.ts
@@ -11,7 +11,7 @@ export interface IRoom {
      * @deprecated usernames will be removed on version 2.0.0
      */
     usernames: Array<string>;
-    uids?: Array<string>;
+    userIds?: Array<string>;
     isDefault?: boolean;
     isReadOnly?: boolean;
     displaySystemMessages?: boolean;

--- a/src/definition/rooms/IRoom.ts
+++ b/src/definition/rooms/IRoom.ts
@@ -11,6 +11,7 @@ export interface IRoom {
      * @deprecated usernames will be removed on version 2.0.0
      */
     usernames: Array<string>;
+    uids?: Array<string>;
     isDefault?: boolean;
     isReadOnly?: boolean;
     displaySystemMessages?: boolean;

--- a/src/server/accessors/RoomBuilder.ts
+++ b/src/server/accessors/RoomBuilder.ts
@@ -143,6 +143,10 @@ export class RoomBuilder implements IRoomBuilder {
       return this.room.customFields;
     }
 
+    public getUserIds(): Array<string> {
+      return this.room.uids;
+    }
+
     public getRoom(): IRoom {
         return this.room;
     }

--- a/src/server/accessors/RoomBuilder.ts
+++ b/src/server/accessors/RoomBuilder.ts
@@ -144,7 +144,7 @@ export class RoomBuilder implements IRoomBuilder {
     }
 
     public getUserIds(): Array<string> {
-      return this.room.uids;
+      return this.room.userIds;
     }
 
     public getRoom(): IRoom {

--- a/src/server/rooms/Room.ts
+++ b/src/server/rooms/Room.ts
@@ -16,7 +16,7 @@ export class Room implements IRoom {
     public updatedAt?: Date;
     public lastModifiedAt?: Date;
     public customFields?: { [key: string]: any };
-    public uids?: Array<string>;
+    public userIds?: Array<string>;
     private _USERNAMES: Array<string>;
 
     /**
@@ -54,7 +54,7 @@ export class Room implements IRoom {
             updatedAt: this.updatedAt,
             lastModifiedAt: this.lastModifiedAt,
             customFields: this.customFields,
-            uids: this.uids,
+            userIds: this.userIds,
         };
     }
 

--- a/src/server/rooms/Room.ts
+++ b/src/server/rooms/Room.ts
@@ -16,6 +16,7 @@ export class Room implements IRoom {
     public updatedAt?: Date;
     public lastModifiedAt?: Date;
     public customFields?: { [key: string]: any };
+    public uids?: Array<string>;
     private _USERNAMES: Array<string>;
 
     /**
@@ -53,6 +54,7 @@ export class Room implements IRoom {
             updatedAt: this.updatedAt,
             lastModifiedAt: this.lastModifiedAt,
             customFields: this.customFields,
+            uids: this.uids,
         };
     }
 


### PR DESCRIPTION
# What? :boat:
Add field `uids` to rooms

# Why? :thinking:
New implementation of group DMs will be adding this fields to all direct message rooms.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
