### PR TITLE
Update TypeScript to 3.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -238,9 +238,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==",
+      "version": "13.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.5.tgz",
+      "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw==",
       "dev": true
     },
     "@types/semver": {
@@ -7354,9 +7354,9 @@
       }
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/adm-zip": "^0.4.31",
     "@types/lodash.clonedeep": "^4.5.3",
     "@types/nedb": "^1.8.5",
-    "@types/node": "^12.7.12",
+    "@types/node": "^13.9.5",
     "@types/semver": "^5.5.0",
     "@types/stack-trace": "0.0.29",
     "@types/uuid": "^3.4.3",
@@ -90,7 +90,7 @@
     "lodash.clonedeep": "^4.5.0",
     "semver": "^5.5.0",
     "stack-trace": "0.0.10",
-    "typescript": "^2.9.2",
+    "typescript": "^3.8.3",
     "uuid": "^3.2.1"
   },
   "nyc": {

--- a/src/server/compiler/AppCompiler.ts
+++ b/src/server/compiler/AppCompiler.ts
@@ -33,6 +33,7 @@ export class AppCompiler {
             noImplicitReturns: true,
             emitDecoratorMetadata: true,
             experimentalDecorators: true,
+            skipLibCheck: true,
             types: ['node'],
             // Set this to true if you would like to see the module resolution process
             traceResolution: false,


### PR DESCRIPTION
Set `skipLibCheck: true` to avoid the following error :  

```
Error: Deployment error: {"status":"compiler_error","messages":[{"file":"/home/vagrant/Rocket.Chat/node_modules/@types/node/index.d.ts","line":165,"character":10,"message":"/home/vagrant/Rocket.Chat/node_modules/@types/node/index.d.ts (166,11): Duplicate identifier 'IteratorResult'."},{"file":"/vagrant/Rocket.Chat.Apps-engine/node_modules/typescript/lib/lib.es2015.iterable.d.ts","line":40,"character":5,"message":"/vagrant/Rocket.Chat.Apps-engine/node_modules/typescript/lib/lib.es2015.iterable.d.ts (41,6): Duplicate identifier 'IteratorResult'."}],"success":false}
```

Tested on a Ubuntu 18 on Vagrant VM, with the following : 

```
 ➔ +-----------------------------------------------+
 ➔ |                 SERVER RUNNING                |
 ➔ +-----------------------------------------------+
 ➔ |                                               |
 ➔ |  Rocket.Chat Version: 3.0.7                   |
 ➔ |       NodeJS Version: 12.14.0 - x64           |
 ➔ |      MongoDB Version: 4.0.6                   |
 ➔ |       MongoDB Engine: wiredTiger              |
 ➔ |             Platform: linux                   |
 ➔ |         Process Port: 23563                   |
 ➔ |             Site URL: http://localhost:3000/  |
 ➔ |     ReplicaSet OpLog: Enabled                 |
 ➔ |          Commit Hash: f69d16950d              |
 ➔ |        Commit Branch: master                  |
 ➔ |                                               |
 ➔ +-----------------------------------------------+
```

To test that deployment is OK, I used the Giphy app, modified to use specific TS 3.8 ECMAScript Private Fields syntax.

Then used rc-apps to deploy it with success : 

![image](https://user-images.githubusercontent.com/25711113/77830204-3b40ff00-7127-11ea-969a-f4fd3689dea4.png)
