### PR TITLE
added support for built-in node modules

### DIFF
--- a/src/server/misc/Utilities.ts
+++ b/src/server/misc/Utilities.ts
@@ -10,9 +10,6 @@ enum AllowedInternalModules {
     buffer,
     crypto,
     dns,
-    http,
-    https,
-    net,
     path,
     querystring,
     readline,
@@ -21,7 +18,6 @@ enum AllowedInternalModules {
     timers,
     util,
     url,
-    zlib,
 }
 
 export class Utilities {

--- a/src/server/misc/Utilities.ts
+++ b/src/server/misc/Utilities.ts
@@ -5,10 +5,23 @@ import * as vm from 'vm';
 import { ICompilerFile } from '../compiler';
 
 enum AllowedInternalModules {
-    path,
-    url,
-    crypto,
+    assert,
+    async_hooks,
     buffer,
+    crypto,
+    dns,
+    http,
+    https,
+    net,
+    path,
+    querystring,
+    readline,
+    stream,
+    string_decoder,
+    timers,
+    util,
+    url,
+    zlib,
 }
 
 export class Utilities {


### PR DESCRIPTION
# What? :boat:
@lolimay following the conversation from [here](https://github.com/RocketChat/Rocket.Chat.Apps-engine/issues/204#issuecomment-605298411) (#204 #249) 

The following is the list of **secure** built-in modules

- assert,
- async_hooks, // The async_hooks module exposes functions to track asynchronous resources.
- buffer,
- crypto,
- dns,    // dns resolver
- timers,
- util,
- stream,     // for working with streaming data in Node.js
- readline,   // reading data from file
- querystring,
- string_decoder,
- url,


The following is a list of **un-secure** built-in modules which I haven't added support of

- child_process,
- cluster     // Cluster is an extensible multi-core server manager
- console     // replacement for console
- constants   // deprecated
- fs,         // file system
- os,
- process,
- worker_threads,
- v8,
- vm,
- inspector,
- module,
- perf_hooks,
- punycode,   // deprecated
- repl,
- trace_events,
- tty,
- http,
- http,
- https,
- path,
- net,
- zlib,       // compress/extract from buffer
 
For the below 4 modules I'm **not sure** whether to include them or not. Currently, I've not included them

- domain,
- events,
- globals,
- tls,        // its secure but this requires openssl installed 

<!--
- Added x;
- Updated y;
- Removed z.
-->

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
