### PR TITLE
Implement the IRoomRead get messages function

### DIFF
--- a/src/definition/accessors/IRoomRead.ts
+++ b/src/definition/accessors/IRoomRead.ts
@@ -45,7 +45,7 @@ export interface IRoomRead {
      * @param roomId the room's id
      * @returns an iterator for messages
      */
-    getMessages(roomId: string): Promise<IterableIterator<IMessage>>;
+    getMessages(roomId: string): Promise<AsyncIterableIterator<IMessage>>;
 
     /**
      * Gets an iterator for all of the users in the provided room.

--- a/src/definition/accessors/IServerSettingRead.ts
+++ b/src/definition/accessors/IServerSettingRead.ts
@@ -31,7 +31,7 @@ export interface IServerSettingRead {
      *
      * @return an iterator of the exposed settings
      */
-    getAll(): Promise<IterableIterator<ISetting>>;
+    getAll(): Promise<AsyncIterableIterator<ISetting>>;
 
     /**
      * Checks if the server setting for the id provided is readable,

--- a/src/server/accessors/RoomRead.ts
+++ b/src/server/accessors/RoomRead.ts
@@ -24,7 +24,7 @@ export class RoomRead implements IRoomRead {
         return this.roomBridge.getCreatorByName(name, this.appId);
     }
 
-    public getMessages(roomId: string): Promise<IterableIterator<IMessage>> {
+    public getMessages(roomId: string): Promise<AsyncIterableIterator<IMessage>> {
         return this.roomBridge.getMessages(roomId, this.appId);
     }
 

--- a/src/server/accessors/ServerSettingRead.ts
+++ b/src/server/accessors/ServerSettingRead.ts
@@ -20,7 +20,7 @@ export class ServerSettingRead implements IServerSettingRead {
         return set.value || set.packageValue;
     }
 
-    public getAll(): Promise<IterableIterator<ISetting>> {
+    public getAll(): Promise<AsyncIterableIterator<ISetting>> {
         throw new Error('Method not implemented.');
         // return this.settingBridge.getAll(this.appId);
     }

--- a/src/server/bridges/IRoomBridge.ts
+++ b/src/server/bridges/IRoomBridge.ts
@@ -8,7 +8,7 @@ export interface IRoomBridge {
     getByName(roomName: string, appId: string): Promise<IRoom>;
     getCreatorById(roomId: string, appId: string): Promise<IUser>;
     getCreatorByName(roomName: string, appId: string): Promise<IUser>;
-    getMessages(roomId: string, appId: string): Promise<IterableIterator<IMessage>>;
+    getMessages(roomId: string, appId: string): Promise<AsyncIterableIterator<IMessage>>;
     getDirectByUsernames(username: Array<string>, appId: string): Promise<IRoom>;
     getMembers(roomId: string, appId: string): Promise<Array<IUser>>;
     update(room: IRoom, members: Array<string>, appId: string): Promise<void>;

--- a/src/server/compiler/AppCompiler.ts
+++ b/src/server/compiler/AppCompiler.ts
@@ -36,6 +36,7 @@ export class AppCompiler {
             types: ['node'],
             // Set this to true if you would like to see the module resolution process
             traceResolution: false,
+            lib: ['lib.esnext.d.ts'],
         };
 
         this.libraryFiles = {};

--- a/src/server/compiler/AppCompiler.ts
+++ b/src/server/compiler/AppCompiler.ts
@@ -36,6 +36,7 @@ export class AppCompiler {
             types: ['node'],
             // Set this to true if you would like to see the module resolution process
             traceResolution: false,
+            // This enables the compiler to identify the `AsyncIterableIterator` name
             lib: ['lib.esnext.d.ts'],
         };
 

--- a/tests/server/accessors/RoomRead.spec.ts
+++ b/tests/server/accessors/RoomRead.spec.ts
@@ -1,23 +1,27 @@
 import { AsyncTest, Expect, SetupFixture } from 'alsatian';
+import { IMessage } from '../../../src/definition/messages';
 import { IRoom } from '../../../src/definition/rooms';
 import { IUser } from '../../../src/definition/users';
 
 import { RoomRead } from '../../../src/server/accessors';
 import { IRoomBridge } from '../../../src/server/bridges';
-import { TestData } from '../../test-data/utilities';
+import { EmptyAsyncIterableIterator, TestData } from '../../test-data/utilities';
 
 export class RoomReadAccessorTestFixture {
     private room: IRoom;
     private user: IUser;
+    private msgIterator: AsyncIterableIterator<IMessage>;
     private mockRoomBridgeWithRoom: IRoomBridge;
 
     @SetupFixture
     public setupFixture() {
         this.room = TestData.getRoom();
         this.user = TestData.getUser();
+        this.msgIterator = new EmptyAsyncIterableIterator<IMessage>();
 
         const theRoom = this.room;
         const theUser = this.user;
+        const theIterator = this.msgIterator;
         this.mockRoomBridgeWithRoom = {
             getById(id, appId): Promise<IRoom> {
                 return Promise.resolve(theRoom);
@@ -36,6 +40,9 @@ export class RoomReadAccessorTestFixture {
             },
             getMembers(name, appId): Promise<Array<IUser>> {
                 return Promise.resolve([theUser]);
+            },
+            getMessages(roomId, appId): Promise<AsyncIterableIterator<IMessage>> {
+                return Promise.resolve(theIterator);
             },
         } as IRoomBridge;
     }
@@ -56,6 +63,8 @@ export class RoomReadAccessorTestFixture {
         Expect(await rr.getCreatorUserByName('testing')).toBe(this.user);
         Expect(await rr.getDirectByUsernames([this.user.username])).toBeDefined();
         Expect(await rr.getDirectByUsernames([this.user.username])).toBe(this.room);
+        Expect(await rr.getMessages('testing')).toBeDefined();
+        Expect(await rr.getMessages('testing')).toBe(this.msgIterator);
     }
 
     @AsyncTest()

--- a/tests/server/compiler/AppCompiler.spec.ts
+++ b/tests/server/compiler/AppCompiler.spec.ts
@@ -23,6 +23,7 @@ export class AppCompilerTestFixture {
             emitDecoratorMetadata: true,
             experimentalDecorators: true,
             traceResolution: false,
+            lib: ['lib.esnext.d.ts'],
         };
 
         Expect((compiler as any).compilerOptions).toEqual(expectedOptions);

--- a/tests/test-data/bridges/roomBridge.ts
+++ b/tests/test-data/bridges/roomBridge.ts
@@ -24,7 +24,7 @@ export class TestsRoomBridge implements IRoomBridge {
         throw new Error('Method not implemented.');
     }
 
-    public getMessages(roomId: string): Promise<IterableIterator<IMessage>> {
+    public getMessages(roomId: string): Promise<AsyncIterableIterator<IMessage>> {
         throw new Error('Method not implemented.');
     }
 

--- a/tests/test-data/utilities.ts
+++ b/tests/test-data/utilities.ts
@@ -190,3 +190,27 @@ export class SimpleClass {
         return this.world;
     }
 }
+
+export class EmptyAsyncIterableIterator<T> implements AsyncIterableIterator<T> {
+    public [Symbol.asyncIterator](): AsyncIterableIterator<T> {
+        return this;
+    }
+
+    public next(): Promise<IteratorResult<T>> {
+        return Promise.resolve({
+            value: {} as T,
+            done: false,
+        });
+    }
+
+    public return?(): Promise<IteratorResult<T>> {
+        return Promise.resolve({
+            done: true,
+            value: undefined,
+        });
+    }
+
+    public throw?(e?: any): Promise<IteratorResult<T>> {
+        throw e;
+    }
+}


### PR DESCRIPTION
# What? :boat:
- Change the IterableIterator to AsyncIterableIterator.

# Why? :thinking:
This way we can fetch the messages one at a time from the database instead of all the time.

# Links :earth_americas:
This one replaces https://github.com/RocketChat/Rocket.Chat.Apps-engine/pull/162 and fixes #161 
