### PR TITLE
New "essentials" mechanism

### DIFF
--- a/src/definition/AppStatus.ts
+++ b/src/definition/AppStatus.ts
@@ -51,6 +51,13 @@ export class AppStatusUtilsDef {
                 return false;
         }
     }
+
+    public isError(status: AppStatus): boolean {
+        return [
+            AppStatus.ERROR_DISABLED,
+            AppStatus.COMPILER_ERROR_DISABLED,
+        ].includes(status);
+    }
 }
 
 export const AppStatusUtils = new AppStatusUtilsDef();

--- a/src/definition/metadata/AppInterface.ts
+++ b/src/definition/metadata/AppInterface.ts
@@ -1,0 +1,36 @@
+export enum AppInterface {
+    // Messages
+    IPreMessageSentPrevent = 'IPreMessageSentPrevent',
+    IPreMessageSentExtend = 'IPreMessageSentExtend',
+    IPreMessageSentModify = 'IPreMessageSentModify',
+    IPostMessageSent = 'IPostMessageSent',
+    IPreMessageDeletePrevent = 'IPreMessageDeletePrevent',
+    IPostMessageDeleted = 'IPostMessageDeleted',
+    IPreMessageUpdatedPrevent = 'IPreMessageUpdatedPrevent',
+    IPreMessageUpdatedExtend = 'IPreMessageUpdatedExtend',
+    IPreMessageUpdatedModify = 'IPreMessageUpdatedModify',
+    IPostMessageUpdated = 'IPostMessageUpdated',
+    // Rooms
+    IPreRoomCreatePrevent = 'IPreRoomCreatePrevent',
+    IPreRoomCreateExtend = 'IPreRoomCreateExtend',
+    IPreRoomCreateModify = 'IPreRoomCreateModify',
+    IPostRoomCreate = 'IPostRoomCreate',
+    IPreRoomDeletePrevent = 'IPreRoomDeletePrevent',
+    IPostRoomDeleted = 'IPostRoomDeleted',
+    IPreRoomUserJoined = 'IPreRoomUserJoined',
+    IPostRoomUserJoined = 'IPostRoomUserJoined',
+    // External Components
+    IPostExternalComponentOpened = 'IPostExternalComponentOpened',
+    IPostExternalComponentClosed = 'IPostExternalComponentClosed',
+    // Blocks
+    IUIKitInteractionHandler = 'IUIKitInteractionHandler',
+    // Livechat
+    IPostLivechatRoomStarted = 'IPostLivechatRoomStarted',
+    IPostLivechatRoomClosed = 'IPostLivechatRoomClosed',
+    /**
+     * @deprecated please use the AppMethod.EXECUTE_POST_LIVECHAT_ROOM_CLOSED method
+     */
+    ILivechatRoomClosedHandler = 'ILivechatRoomClosedHandler',
+    IPostLivechatAgentAssigned = 'IPostLivechatAgentAssigned',
+    IPostLivechatAgentUnassigned = 'IPostLivechatAgentUnassigned',
+}

--- a/src/definition/metadata/IAppInfo.ts
+++ b/src/definition/metadata/IAppInfo.ts
@@ -1,4 +1,4 @@
-import { AppInterface } from '../../server/compiler';
+import { AppInterface } from './AppInterface';
 import { IAppAuthorInfo } from './IAppAuthorInfo';
 
 export interface IAppInfo {

--- a/src/definition/metadata/IAppInfo.ts
+++ b/src/definition/metadata/IAppInfo.ts
@@ -1,3 +1,4 @@
+import { AppInterface } from '../../server/compiler';
 import { IAppAuthorInfo } from './IAppAuthorInfo';
 
 export interface IAppInfo {
@@ -12,4 +13,5 @@ export interface IAppInfo {
     iconFile: string;
     /** Base64 string of the App's icon. */
     iconFileContent?: string;
+    essentials?: [AppInterface];
 }

--- a/src/definition/metadata/index.ts
+++ b/src/definition/metadata/index.ts
@@ -3,6 +3,8 @@ import { IAppAuthorInfo } from './IAppAuthorInfo';
 import { IAppInfo } from './IAppInfo';
 import { RocketChatAssociationModel, RocketChatAssociationRecord } from './RocketChatAssociations';
 
+export * from './AppInterface';
+
 export {
     AppMethod,
     IAppAuthorInfo,

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -222,9 +222,11 @@ export class AppManager {
 
         // Now let's enable the apps which were once enabled
         // but are not currently disabled.
-        for (const rl of this.apps.values()) {
-            if (!AppStatusUtils.isDisabled(rl.getStatus()) && AppStatusUtils.isEnabled(rl.getPreviousStatus())) {
-                await this.enableApp(items.get(rl.getID()), rl, true, rl.getPreviousStatus() === AppStatus.MANUALLY_ENABLED).catch(console.error);
+        for (const app of this.apps.values()) {
+            if (!AppStatusUtils.isDisabled(app.getStatus()) && AppStatusUtils.isEnabled(app.getPreviousStatus())) {
+                await this.enableApp(items.get(app.getID()), app, true, app.getPreviousStatus() === AppStatus.MANUALLY_ENABLED).catch(console.error);
+            } else if (!AppStatusUtils.isError(app.getStatus())) {
+                this.listenerManager.lockEssentialEvents(app);
             }
         }
 

--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -154,6 +154,10 @@ export class ProxiedApp implements IApp {
         return this.app.getAccessors();
     }
 
+    public getEssentials(): IAppInfo['essentials'] {
+        return this.getInfo().essentials;
+    }
+
     public getLatestLicenseValidationResult(): AppLicenseValidationResult {
         return this.latestLicenseValidationResult;
     }

--- a/src/server/bridges/IListenerBridge.ts
+++ b/src/server/bridges/IListenerBridge.ts
@@ -1,7 +1,7 @@
 import { IMessage } from '../../definition/messages';
+import { AppInterface } from '../../definition/metadata';
 import { IRoom } from '../../definition/rooms';
 import { IUIKitIncomingInteraction } from '../../definition/uikit';
-import { AppInterface } from '../compiler';
 
 export interface IListenerBridge {
     messageEvent(int: AppInterface, message: IMessage): Promise<void | boolean | IMessage>;

--- a/src/server/compiler/AppImplements.ts
+++ b/src/server/compiler/AppImplements.ts
@@ -1,41 +1,5 @@
+import { AppInterface } from '../../definition/metadata/AppInterface';
 import { Utilities } from '../misc/Utilities';
-
-export enum AppInterface {
-    // Messages
-    IPreMessageSentPrevent = 'IPreMessageSentPrevent',
-    IPreMessageSentExtend = 'IPreMessageSentExtend',
-    IPreMessageSentModify = 'IPreMessageSentModify',
-    IPostMessageSent = 'IPostMessageSent',
-    IPreMessageDeletePrevent = 'IPreMessageDeletePrevent',
-    IPostMessageDeleted = 'IPostMessageDeleted',
-    IPreMessageUpdatedPrevent = 'IPreMessageUpdatedPrevent',
-    IPreMessageUpdatedExtend = 'IPreMessageUpdatedExtend',
-    IPreMessageUpdatedModify = 'IPreMessageUpdatedModify',
-    IPostMessageUpdated = 'IPostMessageUpdated',
-    // Rooms
-    IPreRoomCreatePrevent = 'IPreRoomCreatePrevent',
-    IPreRoomCreateExtend = 'IPreRoomCreateExtend',
-    IPreRoomCreateModify = 'IPreRoomCreateModify',
-    IPostRoomCreate = 'IPostRoomCreate',
-    IPreRoomDeletePrevent = 'IPreRoomDeletePrevent',
-    IPostRoomDeleted = 'IPostRoomDeleted',
-    IPreRoomUserJoined = 'IPreRoomUserJoined',
-    IPostRoomUserJoined = 'IPostRoomUserJoined',
-    // External Components
-    IPostExternalComponentOpened = 'IPostExternalComponentOpened',
-    IPostExternalComponentClosed = 'IPostExternalComponentClosed',
-    // Blocks
-    IUIKitInteractionHandler = 'IUIKitInteractionHandler',
-    // Livechat
-    IPostLivechatRoomStarted = 'IPostLivechatRoomStarted',
-    IPostLivechatRoomClosed = 'IPostLivechatRoomClosed',
-    /**
-     * @deprecated please use the AppMethod.EXECUTE_POST_LIVECHAT_ROOM_CLOSED method
-     */
-    ILivechatRoomClosedHandler = 'ILivechatRoomClosedHandler',
-    IPostLivechatAgentAssigned = 'IPostLivechatAgentAssigned',
-    IPostLivechatAgentUnassigned = 'IPostLivechatAgentUnassigned',
-}
 
 export class AppImplements {
     private implemented: { [key: string]: boolean };

--- a/src/server/compiler/index.ts
+++ b/src/server/compiler/index.ts
@@ -1,6 +1,6 @@
 import { AppCompiler } from './AppCompiler';
 import { AppFabricationFulfillment } from './AppFabricationFulfillment';
-import { AppImplements, AppInterface } from './AppImplements';
+import { AppImplements } from './AppImplements';
 import { AppPackageParser } from './AppPackageParser';
 import { ICompilerError } from './ICompilerError';
 import { ICompilerFile } from './ICompilerFile';
@@ -11,7 +11,6 @@ export {
     AppCompiler,
     AppFabricationFulfillment,
     AppImplements,
-    AppInterface,
     AppPackageParser,
     ICompilerFile,
     ICompilerError,

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -2,7 +2,7 @@ import { AppsEngineException } from '../../definition/exceptions';
 import { IExternalComponent } from '../../definition/externalComponent';
 import { ILivechatEventContext, ILivechatRoom } from '../../definition/livechat';
 import { IMessage } from '../../definition/messages';
-import { AppMethod } from '../../definition/metadata';
+import { AppInterface, AppMethod } from '../../definition/metadata';
 import { IRoom, IRoomUserJoinedContext } from '../../definition/rooms';
 import { IUIKitIncomingInteraction, IUIKitResponse, IUIKitView, UIKitIncomingInteractionType } from '../../definition/uikit';
 import {
@@ -17,7 +17,6 @@ import {
 import { IUser } from '../../definition/users';
 import { MessageBuilder, MessageExtender, RoomBuilder, RoomExtender } from '../accessors';
 import { AppManager } from '../AppManager';
-import { AppInterface } from '../compiler';
 import { Message } from '../messages/Message';
 import { Utilities } from '../misc/Utilities';
 import { ProxiedApp } from '../ProxiedApp';

--- a/tests/server/compiler/AppFabricationFulfillment.spec.ts
+++ b/tests/server/compiler/AppFabricationFulfillment.spec.ts
@@ -1,10 +1,9 @@
 import { Expect, Test } from 'alsatian';
 import { App } from '../../../src/definition/App';
 import { AppStatus } from '../../../src/definition/AppStatus';
-import { IAppInfo } from '../../../src/definition/metadata';
-
+import { AppInterface, IAppInfo } from '../../../src/definition/metadata';
 import { AppManager } from '../../../src/server/AppManager';
-import { AppFabricationFulfillment, AppInterface, ICompilerError } from '../../../src/server/compiler';
+import { AppFabricationFulfillment, ICompilerError } from '../../../src/server/compiler';
 import { ProxiedApp } from '../../../src/server/ProxiedApp';
 import { IAppStorageItem } from '../../../src/server/storage';
 

--- a/tests/server/compiler/AppImplements.spec.ts
+++ b/tests/server/compiler/AppImplements.spec.ts
@@ -1,6 +1,6 @@
 import { Expect, Test } from 'alsatian';
-
-import { AppImplements, AppInterface } from '../../../src/server/compiler';
+import { AppInterface } from '../../../src/definition/metadata';
+import { AppImplements } from '../../../src/server/compiler';
 
 export class AppImplementsTestFixture {
     @Test()

--- a/tests/server/managers/AppListenerManager.spec.ts
+++ b/tests/server/managers/AppListenerManager.spec.ts
@@ -1,6 +1,6 @@
 import { Expect, SetupFixture, Test } from 'alsatian';
+import { AppInterface } from '../../../src/definition/metadata';
 import { AppManager } from '../../../src/server/AppManager';
-import { AppInterface } from '../../../src/server/compiler';
 import { AppListenerManager } from '../../../src/server/managers';
 import { ProxiedApp } from '../../../src/server/ProxiedApp';
 


### PR DESCRIPTION
# What? :boat:
This is a mechanism that allows an app to register itself as "essential" to an event in the Rocket.Chat lifecycle.

If an app that is "essential" is disabled during the execution of such event, an error is thrown.

# Why? :thinking:
Currently, we have a problem regarding the state management of apps in HA setups. Each instance in the cluster has to manage the apps that are enabled/disabled, and should communicate any changes to the other instances when they happen, but this has shown to be unreliable in times when there is high usage.

This mechanism presents a way of "shielding" workspaces that require custom rules for critical events (message sending, room creating, etc.) to take place from this unpredictable problems.

# Links :earth_americas:
https://github.com/RocketChat/Rocket.Chat/pull/17656

# PS :eyes:
