### PR TITLE
Add blockId to uikit block incoming interaction

### DIFF
--- a/src/definition/uikit/IUIKitIncomingInteraction.ts
+++ b/src/definition/uikit/IUIKitIncomingInteraction.ts
@@ -17,8 +17,8 @@ export interface IUIKitIncomingInteraction {
     container: IUIKitIncomingInteractionModalContainer | IUIKitIncomingInteractionMessageContainer;
     user: IUser;
     appId: string;
-    actionId: string;
     payload: object;
+    actionId?: string;
     triggerId?: string;
     room?: IRoom;
     message?: IMessage;

--- a/src/definition/uikit/UIKitIncomingInteractionTypes.ts
+++ b/src/definition/uikit/UIKitIncomingInteractionTypes.ts
@@ -9,8 +9,8 @@ import {
 
 export interface IUIKitBaseIncomingInteraction {
     appId: string;
-    actionId: string;
     user: IUser;
+    actionId?: string;
     room?: IRoom;
     triggerId?: string;
 }
@@ -19,6 +19,7 @@ export interface IUIKitBlockIncomingInteraction extends IUIKitBaseIncomingIntera
     value?: string;
     message?: IMessage;
     triggerId: string;
+    blockId: string;
     room: IUIKitBaseIncomingInteraction['room'];
     container: IUIKitIncomingInteractionModalContainer | IUIKitIncomingInteractionMessageContainer;
 }

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -787,11 +787,12 @@ export class AppListenerManager {
 
             switch (interactionType) {
                 case UIKitIncomingInteractionType.BLOCK: {
-                    const { value } = interactionData.payload as { value: string };
+                    const { value, blockId } = interactionData.payload as { value: string; blockId: string };
 
                     return new UIKitBlockInteractionContext({
                         appId,
                         actionId,
+                        blockId,
                         user,
                         room,
                         triggerId,


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Adds the `blockId` property to UIKit block interactions interface

# Why? :thinking:
<!--Additional explanation if needed-->
This information is already being sent by clients and was just ignored by the engine. It also enriches the context information passed to the Apps

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
