### PR TITLE
Add multiline property to PlainTextInputElement

### DIFF
--- a/src/definition/uikit/blocks/Elements.ts
+++ b/src/definition/uikit/blocks/Elements.ts
@@ -54,6 +54,7 @@ export interface IOverflowMenuElement extends IInteractiveElement {
 export interface IPlainTextInputElement extends IInputElement {
     type: BlockElementType.PLAIN_TEXT_INPUT;
     initialValue?: string;
+    multiline?: boolean;
 }
 
 export interface ISelectElement extends IInputElement {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Adds the `multiline` property to `IPlainTextInputElement`

# Why? :thinking:
<!--Additional explanation if needed-->
This allows apps to open `textareas` with UIKit library

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
