### PR TITLE
Removing TS compiler

### DIFF
--- a/src/definition/metadata/IAppInfo.ts
+++ b/src/definition/metadata/IAppInfo.ts
@@ -11,6 +11,7 @@ export interface IAppInfo {
     author: IAppAuthorInfo;
     classFile: string;
     iconFile: string;
+    implements: Array<AppInterface>;
     /** Base64 string of the App's icon. */
     iconFileContent?: string;
     essentials?: Array<AppInterface>;

--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.16.0-beta",
+  "version": "1.17.0-alpha",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -387,7 +387,11 @@ export class AppManager {
             info: result.info,
             status: AppStatus.UNKNOWN,
             zip: appPackage.toString('base64'),
-            compiled: result.files,
+            // tslint:disable-next-line: max-line-length
+            compiled: Object.entries(result.files).reduce(
+                (files, [key, value]) => (files[key.replace(/\./gi, '$')] = value, files),
+                {} as {[key: string]: string},
+            ),
             languageContent: result.languageContent,
             settings: {},
             implemented: result.implemented.getValues(),

--- a/src/server/compiler/AppCompiler.ts
+++ b/src/server/compiler/AppCompiler.ts
@@ -1,301 +1,29 @@
-import * as fs from 'fs';
 import * as path from 'path';
-import * as ts from 'typescript';
 import * as vm from 'vm';
 
 import { App } from '../../definition/App';
-import { AppMethod, IAppInfo } from '../../definition/metadata';
+import { AppMethod } from '../../definition/metadata';
 import { AppAccessors } from '../accessors';
 import { AppManager } from '../AppManager';
-import { CompilerError, MustContainFunctionError, MustExtendAppError } from '../errors';
+import { MustContainFunctionError, MustExtendAppError } from '../errors';
 import { AppConsole } from '../logging';
 import { Utilities } from '../misc/Utilities';
 import { ProxiedApp } from '../ProxiedApp';
 import { IAppStorageItem } from '../storage/IAppStorageItem';
-import { AppImplements } from './AppImplements';
-import { ICompilerError } from './ICompilerError';
-import { ICompilerFile } from './ICompilerFile';
-import { ICompilerResult } from './ICompilerResult';
 
 export class AppCompiler {
-    private readonly compilerOptions: ts.CompilerOptions;
-    private libraryFiles: { [s: string]: ICompilerFile };
+    public normalizeStorageFiles(files: { [key: string]: string }): { [key: string]: string } {
+        const result: { [key: string]: string } = {};
 
-    constructor() {
-        this.compilerOptions = {
-            target: ts.ScriptTarget.ES2017,
-            module: ts.ModuleKind.CommonJS,
-            moduleResolution: ts.ModuleResolutionKind.NodeJs,
-            declaration: false,
-            noImplicitAny: false,
-            removeComments: true,
-            strictNullChecks: true,
-            noImplicitReturns: true,
-            emitDecoratorMetadata: true,
-            experimentalDecorators: true,
-            types: ['node'],
-            // Set this to true if you would like to see the module resolution process
-            traceResolution: false,
-        };
-
-        this.libraryFiles = {};
-    }
-
-    public storageFilesToCompiler(files: { [key: string]: string }): { [key: string]: ICompilerFile } {
-        const result: { [key: string]: ICompilerFile } = {};
-
-        Object.keys(files).forEach((key) => {
-            const name = key.replace(/\$/g, '.');
-            result[name] = {
-                name,
-                content: files[key],
-                version: 0,
-                compiled: files[key],
-            };
-        });
-
-        return result;
-    }
-
-    public getLibraryFile(fileName: string): ICompilerFile {
-        if (!fileName.endsWith('.d.ts')) {
-            return undefined;
-        }
-
-        const norm = path.normalize(fileName);
-
-        if (this.libraryFiles[norm]) {
-            return this.libraryFiles[norm];
-        }
-
-        if (!fs.existsSync(fileName)) {
-            return undefined;
-        }
-
-        this.libraryFiles[norm] = {
-            name: norm,
-            content: fs.readFileSync(fileName).toString(),
-            version: 0,
-        };
-
-        return this.libraryFiles[norm];
-    }
-
-    public resolvePath(
-        containingFile: string,
-        moduleName: string,
-        cwd: string,
-    ): string {
-        const currentFolderPath = path.dirname(containingFile).replace(cwd.replace(/\/$/, ''), '');
-        const modulePath = path.join(currentFolderPath, moduleName);
-
-        // Let's ensure we search for the App's modules first
-        const transformedModule = Utilities.transformModuleForCustomRequire(modulePath);
-        if (transformedModule) {
-            return transformedModule;
-        }
-    }
-
-    public resolver(
-        moduleName: string,
-        resolvedModules: Array<ts.ResolvedModule>,
-        containingFile: string,
-        result: ICompilerResult,
-        cwd: string,
-        moduleResHost: ts.ModuleResolutionHost,
-    ) {
-        // Keep compatibility with apps importing apps-ts-definition
-        moduleName = moduleName.replace(/@rocket.chat\/apps-ts-definition\//, '@rocket.chat/apps-engine/definition/');
-
-        if (Utilities.allowedInternalModuleRequire(moduleName)) {
-            return resolvedModules.push({ resolvedFileName: moduleName + '.js' });
-        }
-
-        const resolvedPath = this.resolvePath(containingFile, moduleName, cwd);
-        if (result.files[resolvedPath]) {
-            return resolvedModules.push({ resolvedFileName: resolvedPath });
-        }
-
-        // Now, let's try the "standard" resolution but with our little twist on it
-        const rs = ts.resolveModuleName(moduleName, containingFile, this.compilerOptions, moduleResHost);
-        if (rs.resolvedModule) {
-            return resolvedModules.push(rs.resolvedModule);
-        }
-
-        console.log(`Failed to resolve module: ${ moduleName }`);
-    }
-
-    /**
-     * Attempts to compile the TypeScript down into JavaScript which we can understand.
-     * It returns the files, what the App implements, and whether there are errors or not.
-     *
-     * @param info the App's information (name, version, etc)
-     * @param theFiles the actual files to try and compile
-     * @returns the results of trying to compile, including errors
-     */
-    public toJs(info: IAppInfo, theFiles: { [s: string]: ICompilerFile }): ICompilerResult {
-        if (!theFiles || !theFiles[info.classFile] || !this.isValidFile(theFiles[info.classFile])) {
-            throw new Error(`Invalid App package. Could not find the classFile (${info.classFile}) file.`);
-        }
-
-        const result: ICompilerResult = {
-            files: theFiles,
-            implemented: new AppImplements(),
-            compilerErrors: new Array<ICompilerError>(),
-        };
-
-        // Verify all file names are normalized
-        // and that the files are valid
-        Object.keys(result.files).forEach((key) => {
-            if (!this.isValidFile(result.files[key])) {
-                throw new Error(`Invalid TypeScript file in the App ${info.name} in the file "${key}".`);
-            }
-
-            result.files[key].name = path.normalize(result.files[key].name);
-        });
-
-        // Our "current working directory" needs to be adjusted for module resolution
-        const cwd = __dirname.includes('node_modules/@rocket.chat/apps-engine')
-            ? __dirname.split('node_modules/@rocket.chat/apps-engine')[0] : process.cwd();
-
-        const host: ts.LanguageServiceHost = {
-            getScriptFileNames: () => Object.keys(result.files),
-            getScriptVersion: (fileName) => {
-                fileName = path.normalize(fileName);
-                const file = result.files[fileName] || this.getLibraryFile(fileName);
-                return file && file.version.toString();
-            },
-            getScriptSnapshot: (fileName) => {
-                fileName = path.normalize(fileName);
-                const file = result.files[fileName] || this.getLibraryFile(fileName);
-
-                if (!file || !file.content) {
-                    return;
-                }
-
-                return ts.ScriptSnapshot.fromString(file.content);
-            },
-            getCompilationSettings: () => this.compilerOptions,
-            getCurrentDirectory: () => cwd,
-            getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(this.compilerOptions),
-            fileExists: (fileName: string): boolean => {
-                return ts.sys.fileExists(fileName);
-            },
-            readFile: (fileName: string): string | undefined => {
-                return ts.sys.readFile(fileName);
-            },
-            resolveModuleNames: (moduleNames: Array<string>, containingFile: string): Array<ts.ResolvedModule> => {
-                const resolvedModules = new Array<ts.ResolvedModule>();
-                // tslint:disable-next-line
-                const moduleResHost: ts.ModuleResolutionHost = { fileExists: host.fileExists, readFile: host.readFile, trace: (traceDetail) => console.log(traceDetail) };
-
-                for (const moduleName of moduleNames) {
-                    this.resolver(moduleName, resolvedModules, containingFile, result, cwd, moduleResHost);
-                }
-
-                if (moduleNames.length > resolvedModules.length) {
-                    const failedCount = moduleNames.length - resolvedModules.length;
-                    console.log(`Failed to resolved ${ failedCount } modules for ${ info.name } v${ info.version }!`);
-                }
-
-                return resolvedModules;
-            },
-        };
-
-        const languageService = ts.createLanguageService(host, ts.createDocumentRegistry());
-
-        const coDiag = languageService.getCompilerOptionsDiagnostics();
-        if (coDiag.length !== 0) {
-            console.log(coDiag);
-
-            console.error('A VERY UNEXPECTED ERROR HAPPENED THAT SHOULD NOT!');
-            console.error('Please report this error with a screenshot of the logs. ' +
-                `Also, please email a copy of the App being installed/updated: ${ info.name } v${ info.version } (${ info.id })`);
-
-            throw new CompilerError(`Language Service's Compiler Options Diagnostics contains ${ coDiag.length } diagnostics.`);
-        }
-
-        const src = languageService.getProgram().getSourceFile(info.classFile);
-        ts.forEachChild(src, (n) => {
-            if (n.kind === ts.SyntaxKind.ClassDeclaration) {
-                ts.forEachChild(n, (node) => {
-                    if (node.kind === ts.SyntaxKind.HeritageClause) {
-                        const e = node as ts.HeritageClause;
-
-                        ts.forEachChild(node, (nn) => {
-                            if (e.token === ts.SyntaxKind.ExtendsKeyword) {
-                                if (nn.getText() !== 'App') {
-                                    throw new MustExtendAppError();
-                                }
-                            } else if (e.token === ts.SyntaxKind.ImplementsKeyword) {
-                                result.implemented.doesImplement(nn.getText());
-                            } else {
-                                console.log(e.token, nn.getText());
-                            }
-                        });
-                    }
-                });
-            }
-        });
-
-        function logErrors(fileName: string) {
-            const allDiagnostics = languageService.getCompilerOptionsDiagnostics()
-                .concat(languageService.getSyntacticDiagnostics(fileName))
-                .concat(languageService.getSemanticDiagnostics(fileName));
-
-            allDiagnostics.forEach((diagnostic) => {
-                const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-
-                if (diagnostic.file) {
-                    const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
-                    console.log(`  Error ${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
-                } else {
-                    console.log(`  Error: ${message}`);
-                }
-            });
-        }
-
-        const preEmit = ts.getPreEmitDiagnostics(languageService.getProgram());
-        preEmit.forEach((dia: ts.Diagnostic) => {
-            // Only filter out the typing diagnostics which are something other than errors
-            if (dia.category !== ts.DiagnosticCategory.Error) {
-                return;
-            }
-
-            const msg = ts.flattenDiagnosticMessageText(dia.messageText, '\n');
-            if (!dia.file) {
-                console.warn(msg);
-                return;
-            }
-
-            const { line, character } = dia.file.getLineAndCharacterOfPosition(dia.start);
-            // console.warn(`  Error ${dia.file.fileName} (${line + 1},${character + 1}): ${msg}`);
-
-            result.compilerErrors.push({
-                file: dia.file.fileName,
-                line,
-                character,
-                message: `${dia.file.fileName} (${line + 1},${character + 1}): ${msg}`,
-            });
-        });
-
-        Object.keys(result.files).forEach((key) => {
-            const file: ICompilerFile = result.files[key];
-            const output: ts.EmitOutput = languageService.getEmitOutput(file.name);
-
-            if (output.emitSkipped) {
-                console.log('Emitting failed for:', file.name);
-                logErrors(file.name);
-            }
-
-            file.compiled = output.outputFiles[0].text;
+        Object.entries(files).forEach(([name, content]) => {
+            result[name.replace(/\$/g, '.')] = content;
         });
 
         return result;
     }
 
     public toSandBox(manager: AppManager, storage: IAppStorageItem): ProxiedApp {
-        const files = this.storageFilesToCompiler(storage.compiled);
+        const files = this.normalizeStorageFiles(storage.compiled);
 
         if (typeof files[path.normalize(storage.info.classFile)] === 'undefined') {
             throw new Error(`Invalid App package for "${storage.info.name}". ` +
@@ -305,7 +33,7 @@ export class AppCompiler {
         const customRequire = Utilities.buildCustomRequire(files);
         const context = vm.createContext({ require: customRequire, exports, process: {}, console });
 
-        const script = new vm.Script(files[path.normalize(storage.info.classFile)].compiled);
+        const script = new vm.Script(files[path.normalize(storage.info.classFile)]);
         const result = script.runInContext(context);
 
         if (typeof result !== 'function') {
@@ -356,15 +84,5 @@ export class AppCompiler {
         manager.getLogStorage().storeEntries(app.getID(), logger);
 
         return app;
-    }
-
-    private isValidFile(file: ICompilerFile): boolean {
-        if (!file || !file.name || !file.content) {
-            return false;
-        }
-
-        return file.name.trim() !== ''
-            && path.normalize(file.name)
-            && file.content.trim() !== '';
     }
 }

--- a/src/server/compiler/AppFabricationFulfillment.ts
+++ b/src/server/compiler/AppFabricationFulfillment.ts
@@ -1,19 +1,16 @@
 import { IAppInfo } from '../../definition/metadata';
 import { AppLicenseValidationResult } from '../marketplace/license';
 import { ProxiedApp } from '../ProxiedApp';
-import { ICompilerError } from './ICompilerError';
 
 export class AppFabricationFulfillment {
     public info: IAppInfo;
     public app: ProxiedApp;
     public implemented: { [int: string]: boolean };
-    public compilerErrors: Array<ICompilerError>;
     public licenseValidationResult: AppLicenseValidationResult;
     public storageError: string;
     public appUserError: object;
 
     constructor() {
-        this.compilerErrors = new Array<ICompilerError>();
         this.licenseValidationResult = new AppLicenseValidationResult();
     }
 
@@ -40,14 +37,6 @@ export class AppFabricationFulfillment {
 
     public getImplementedInferfaces(): { [int: string]: boolean } {
         return this.implemented;
-    }
-
-    public setCompilerErrors(errors: Array<ICompilerError>): void {
-        this.compilerErrors = errors;
-    }
-
-    public getCompilerErrors(): Array<ICompilerError> {
-        return this.compilerErrors;
     }
 
     public setStorageError(errorMessage: string): void {

--- a/src/server/compiler/AppPackageParser.ts
+++ b/src/server/compiler/AppPackageParser.ts
@@ -41,6 +41,8 @@ export class AppPackageParser {
             throw new Error('Invalid App package. No "app.json" file.');
         }
 
+        info.classFile = info.classFile.replace('.ts', '.js');
+
         if (!semver.satisfies(this.appsEngineVersion, info.requiredApiVersion)) {
             throw new RequiredApiVersionError(info, this.appsEngineVersion);
         }
@@ -48,7 +50,7 @@ export class AppPackageParser {
         // Load all of the TypeScript only files
         const files: { [s: string]: string } = {};
 
-        zip.getEntries().filter((entry) => !entry.isDirectory).forEach((entry) => {
+        zip.getEntries().filter((entry) => !entry.isDirectory && entry.entryName.endsWith('.js')).forEach((entry) => {
             const norm = path.normalize(entry.entryName);
 
             // Files which start with `.` are supposed to be hidden
@@ -74,7 +76,9 @@ export class AppPackageParser {
 
         const implemented = new AppImplements();
 
-        info.implements.forEach((interfaceName) => implemented.doesImplement(interfaceName));
+        if (Array.isArray(info.implements)) {
+            info.implements.forEach((interfaceName) => implemented.doesImplement(interfaceName));
+        }
 
         return {
             info,

--- a/src/server/compiler/ICompilerError.ts
+++ b/src/server/compiler/ICompilerError.ts
@@ -1,6 +1,0 @@
-export interface ICompilerError {
-    file: string;
-    line: number;
-    character: number;
-    message: string;
-}

--- a/src/server/compiler/ICompilerFile.ts
+++ b/src/server/compiler/ICompilerFile.ts
@@ -1,6 +1,0 @@
-export interface ICompilerFile {
-    name: string;
-    content: string;
-    version: number;
-    compiled?: string;
-}

--- a/src/server/compiler/ICompilerResult.ts
+++ b/src/server/compiler/ICompilerResult.ts
@@ -1,9 +1,0 @@
-import { AppImplements } from './AppImplements';
-import { ICompilerError } from './ICompilerError';
-import { ICompilerFile } from './ICompilerFile';
-
-export interface ICompilerResult {
-    files: { [s: string]: ICompilerFile };
-    implemented: AppImplements;
-    compilerErrors: Array<ICompilerError>;
-}

--- a/src/server/compiler/IParseAppPackageResult.ts
+++ b/src/server/compiler/IParseAppPackageResult.ts
@@ -1,11 +1,9 @@
 import { IAppInfo } from '../../definition/metadata';
 import { AppImplements } from './AppImplements';
-import { ICompilerError } from './ICompilerError';
 
-export interface IParseZipResult {
+export interface IParseAppPackageResult {
     info: IAppInfo;
-    compiledFiles: { [key: string]: string };
+    files: { [key: string]: string };
     languageContent: { [key: string]: object };
     implemented: AppImplements;
-    compilerErrors: Array<ICompilerError>;
 }

--- a/src/server/compiler/index.ts
+++ b/src/server/compiler/index.ts
@@ -2,18 +2,12 @@ import { AppCompiler } from './AppCompiler';
 import { AppFabricationFulfillment } from './AppFabricationFulfillment';
 import { AppImplements } from './AppImplements';
 import { AppPackageParser } from './AppPackageParser';
-import { ICompilerError } from './ICompilerError';
-import { ICompilerFile } from './ICompilerFile';
-import { ICompilerResult } from './ICompilerResult';
-import { IParseZipResult } from './IParseZipResult';
+import { IParseAppPackageResult } from './IParseAppPackageResult';
 
 export {
     AppCompiler,
     AppFabricationFulfillment,
     AppImplements,
     AppPackageParser,
-    ICompilerFile,
-    ICompilerError,
-    ICompilerResult,
-    IParseZipResult,
+    IParseAppPackageResult,
 };

--- a/src/server/misc/Utilities.ts
+++ b/src/server/misc/Utilities.ts
@@ -2,8 +2,6 @@ import cloneDeep = require('lodash.clonedeep');
 import * as path from 'path';
 import * as vm from 'vm';
 
-import { ICompilerFile } from '../compiler';
-
 enum AllowedInternalModules {
     path,
     url,
@@ -41,7 +39,7 @@ export class Utilities {
         return moduleName in AllowedInternalModules;
     }
 
-    public static buildCustomRequire(files: { [s: string]: ICompilerFile }, currentPath: string = '.'): (mod: string) => {} {
+    public static buildCustomRequire(files: { [s: string]: string }, currentPath: string = '.'): (mod: string) => {} {
         return function _requirer(mod: string): any {
             // Keep compatibility with apps importing apps-ts-definition
             if (mod.startsWith('@rocket.chat/apps-ts-definition/')) {
@@ -75,7 +73,7 @@ export class Utilities {
                     process: {},
                 });
 
-                vm.runInContext(files[transformedModule].compiled, context);
+                vm.runInContext(files[transformedModule], context);
 
                 return ourExport;
             }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Removing the compilation process for the apps. From this point on, we're expecting the apps package to contain their compiled versions already.

This is just part of the project - most of the work will be done on other packages.

Rocket.Chat PR: https://github.com/RocketChat/Rocket.Chat/pull/18687

# Why? :thinking:
<!--Additional explanation if needed-->
By doing this we achieve:

* A smaller dependency tree for the package, since we will not require the `typescript` package anymore.
* A smaller memory footprint in the Rocket.Chat server, as we will not load `typescript` in runtime anymore.
* A smaller surface for compilation errors to happen when updating the Apps-Engine version in a running server.
* A shorter start-up time for the Rocket.Chat server, as it will not need to compile all installed apps anymore.
* A more flexible development experience, not tied to the `typescript` version we ship with the Apps-Engine.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
