### PR TITLE
[UIKit] New event handlers for the livechat widget

### DIFF
--- a/src/definition/metadata/AppInterface.ts
+++ b/src/definition/metadata/AppInterface.ts
@@ -24,6 +24,7 @@ export enum AppInterface {
     IPostExternalComponentClosed = 'IPostExternalComponentClosed',
     // Blocks
     IUIKitInteractionHandler = 'IUIKitInteractionHandler',
+    IUIKitLivechatInteractionHandler = 'IUIKitLivechatInteractionHandler',
     // Livechat
     IPostLivechatRoomStarted = 'IPostLivechatRoomStarted',
     IPostLivechatRoomClosed = 'IPostLivechatRoomClosed',

--- a/src/definition/metadata/AppMethod.ts
+++ b/src/definition/metadata/AppMethod.ts
@@ -53,8 +53,6 @@ export enum AppMethod {
     UIKIT_VIEW_SUBMIT = 'executeViewSubmitHandler',
     UIKIT_VIEW_CLOSE = 'executeViewClosedHandler',
     UIKIT_LIVECHAT_BLOCK_ACTION = 'executeLivechatBlockActionHandler',
-    UIKIT_LIVECHAT_VIEW_SUBMIT = 'executeLivechatViewSubmitHandler',
-    UIKIT_LIVECHAT_VIEW_CLOSE = 'executeLivechatViewClosedHandler',
     // Livechat
     EXECUTE_POST_LIVECHAT_ROOM_STARTED = 'executePostLivechatRoomStarted',
     /**

--- a/src/definition/metadata/AppMethod.ts
+++ b/src/definition/metadata/AppMethod.ts
@@ -52,6 +52,9 @@ export enum AppMethod {
     UIKIT_BLOCK_ACTION = 'executeBlockActionHandler',
     UIKIT_VIEW_SUBMIT = 'executeViewSubmitHandler',
     UIKIT_VIEW_CLOSE = 'executeViewClosedHandler',
+    UIKIT_LIVECHAT_BLOCK_ACTION = 'executeLivechatBlockActionHandler',
+    UIKIT_LIVECHAT_VIEW_SUBMIT = 'executeLivechatViewSubmitHandler',
+    UIKIT_LIVECHAT_VIEW_CLOSE = 'executeLivechatViewClosedHandler',
     // Livechat
     EXECUTE_POST_LIVECHAT_ROOM_STARTED = 'executePostLivechatRoomStarted',
     /**

--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.17.0-alpha",
+  "version": "1.17.0-beta",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",

--- a/src/definition/uikit/index.ts
+++ b/src/definition/uikit/index.ts
@@ -4,3 +4,4 @@ export * from './IUIKitActionHandler';
 export * from './IUIKitInteractionType';
 export * from './UIKitInteractionContext';
 export * from './blocks';
+export * from './livechat';

--- a/src/definition/uikit/livechat/IUIKitLivechatActionHandler.ts
+++ b/src/definition/uikit/livechat/IUIKitLivechatActionHandler.ts
@@ -1,7 +1,7 @@
 import { IHttp, IModify, IPersistence, IRead } from '../../accessors';
 import { AppMethod } from '../../metadata';
 import { IUIKitResponse } from '../IUIKitInteractionType';
-import { UIKitLivechatBlockInteractionContext, UIKitLivechatViewCloseInteractionContext, UIKitLivechatViewSubmitInteractionContext } from './UIKitLivechatInteractionContext';
+import { UIKitLivechatBlockInteractionContext } from './UIKitLivechatInteractionContext';
 
 /** Handler for after a message is sent. */
 export interface IUIKitLivechatInteractionHandler {
@@ -15,38 +15,6 @@ export interface IUIKitLivechatInteractionHandler {
      */
     [AppMethod.UIKIT_LIVECHAT_BLOCK_ACTION]?(
         context: UIKitLivechatBlockInteractionContext,
-        read: IRead,
-        http: IHttp,
-        persistence: IPersistence,
-        modify: IModify,
-    ): Promise<IUIKitResponse>;
-
-    /**
-     * Method called when a modal is submitted.
-     *
-     * @param context
-     * @param read An accessor to the environment
-     * @param http An accessor to the outside world
-     * @param persistence An accessor to the App's persistence
-     */
-    [AppMethod.UIKIT_LIVECHAT_VIEW_SUBMIT]?(
-        context: UIKitLivechatViewSubmitInteractionContext,
-        read: IRead,
-        http: IHttp,
-        persistence: IPersistence,
-        modify: IModify,
-    ): Promise<IUIKitResponse>;
-
-    /**
-     * Method called when a modal is closed.
-     *
-     * @param context
-     * @param read An accessor to the environment
-     * @param http An accessor to the outside world
-     * @param persistence An accessor to the App's persistence
-     */
-    [AppMethod.UIKIT_LIVECHAT_VIEW_CLOSE]?(
-        context: UIKitLivechatViewCloseInteractionContext,
         read: IRead,
         http: IHttp,
         persistence: IPersistence,

--- a/src/definition/uikit/livechat/IUIKitLivechatActionHandler.ts
+++ b/src/definition/uikit/livechat/IUIKitLivechatActionHandler.ts
@@ -1,0 +1,55 @@
+import { IHttp, IModify, IPersistence, IRead } from '../../accessors';
+import { AppMethod } from '../../metadata';
+import { IUIKitResponse } from '../IUIKitInteractionType';
+import { UIKitLivechatBlockInteractionContext, UIKitLivechatViewCloseInteractionContext, UIKitLivechatViewSubmitInteractionContext } from './UIKitLivechatInteractionContext';
+
+/** Handler for after a message is sent. */
+export interface IUIKitLivechatInteractionHandler {
+    /**
+     * Method called when a block action is invoked.
+     *
+     * @param context
+     * @param read An accessor to the environment
+     * @param http An accessor to the outside world
+     * @param persistence An accessor to the App's persistence
+     */
+    [AppMethod.UIKIT_LIVECHAT_BLOCK_ACTION]?(
+        context: UIKitLivechatBlockInteractionContext,
+        read: IRead,
+        http: IHttp,
+        persistence: IPersistence,
+        modify: IModify,
+    ): Promise<IUIKitResponse>;
+
+    /**
+     * Method called when a modal is submitted.
+     *
+     * @param context
+     * @param read An accessor to the environment
+     * @param http An accessor to the outside world
+     * @param persistence An accessor to the App's persistence
+     */
+    [AppMethod.UIKIT_LIVECHAT_VIEW_SUBMIT]?(
+        context: UIKitLivechatViewSubmitInteractionContext,
+        read: IRead,
+        http: IHttp,
+        persistence: IPersistence,
+        modify: IModify,
+    ): Promise<IUIKitResponse>;
+
+    /**
+     * Method called when a modal is closed.
+     *
+     * @param context
+     * @param read An accessor to the environment
+     * @param http An accessor to the outside world
+     * @param persistence An accessor to the App's persistence
+     */
+    [AppMethod.UIKIT_LIVECHAT_VIEW_CLOSE]?(
+        context: UIKitLivechatViewCloseInteractionContext,
+        read: IRead,
+        http: IHttp,
+        persistence: IPersistence,
+        modify: IModify,
+    ): Promise<IUIKitResponse>;
+}

--- a/src/definition/uikit/livechat/IUIKitLivechatActionHandler.ts
+++ b/src/definition/uikit/livechat/IUIKitLivechatActionHandler.ts
@@ -3,7 +3,7 @@ import { AppMethod } from '../../metadata';
 import { IUIKitResponse } from '../IUIKitInteractionType';
 import { UIKitLivechatBlockInteractionContext } from './UIKitLivechatInteractionContext';
 
-/** Handler for after a message is sent. */
+/** Handler for UIKit interactions in the livechat widget. */
 export interface IUIKitLivechatInteractionHandler {
     /**
      * Method called when a block action is invoked.

--- a/src/definition/uikit/livechat/IUIKitLivechatIncomingInteraction.ts
+++ b/src/definition/uikit/livechat/IUIKitLivechatIncomingInteraction.ts
@@ -1,0 +1,20 @@
+import { IVisitor } from '../../livechat';
+import { IMessage } from '../../messages';
+import { IRoom } from '../../rooms';
+import { UIKitIncomingInteractionType } from '../IUIKitIncomingInteraction';
+import {
+    IUIKitIncomingInteractionMessageContainer,
+    IUIKitIncomingInteractionModalContainer,
+} from '../UIKitIncomingInteractionContainer';
+
+export interface IUIKitLivechatIncomingInteraction {
+    type: UIKitIncomingInteractionType;
+    container: IUIKitIncomingInteractionModalContainer | IUIKitIncomingInteractionMessageContainer;
+    visitor: IVisitor;
+    appId: string;
+    payload: object;
+    actionId?: string;
+    triggerId?: string;
+    room?: IRoom;
+    message?: IMessage;
+}

--- a/src/definition/uikit/livechat/UIKitLivechatIncomingInteractionType.ts
+++ b/src/definition/uikit/livechat/UIKitLivechatIncomingInteractionType.ts
@@ -1,7 +1,6 @@
 import { IVisitor } from '../../livechat';
 import { IMessage } from '../../messages';
 import { IRoom } from '../../rooms';
-import { IUIKitView } from '../IUIKitView';
 import {
     IUIKitIncomingInteractionMessageContainer,
     IUIKitIncomingInteractionModalContainer,
@@ -23,14 +22,4 @@ export interface IUIKitLivechatBlockIncomingInteraction extends IUIKitLivechatBa
     blockId: string;
     room: IUIKitLivechatBaseIncomingInteraction['room'];
     container: IUIKitIncomingInteractionModalContainer | IUIKitIncomingInteractionMessageContainer;
-}
-
-export interface IUIKitLivechatViewSubmitIncomingInteraction extends IUIKitLivechatBaseIncomingInteraction {
-    view: IUIKitView;
-    triggerId: string;
-}
-
-export interface IUIKitLivechatViewCloseIncomingInteraction extends IUIKitLivechatBaseIncomingInteraction {
-    view: IUIKitView;
-    isCleared: boolean;
 }

--- a/src/definition/uikit/livechat/UIKitLivechatIncomingInteractionType.ts
+++ b/src/definition/uikit/livechat/UIKitLivechatIncomingInteractionType.ts
@@ -1,0 +1,36 @@
+import { IVisitor } from '../../livechat';
+import { IMessage } from '../../messages';
+import { IRoom } from '../../rooms';
+import { IUIKitView } from '../IUIKitView';
+import {
+    IUIKitIncomingInteractionMessageContainer,
+    IUIKitIncomingInteractionModalContainer,
+} from '../UIKitIncomingInteractionContainer';
+
+export interface IUIKitLivechatBaseIncomingInteraction {
+    appId: string;
+    visitor: IVisitor;
+    actionId?: string;
+    room?: IRoom;
+    triggerId?: string;
+}
+
+export interface IUIKitLivechatBlockIncomingInteraction extends IUIKitLivechatBaseIncomingInteraction {
+    value?: string;
+    message?: IMessage;
+    triggerId: string;
+    actionId: string;
+    blockId: string;
+    room: IUIKitLivechatBaseIncomingInteraction['room'];
+    container: IUIKitIncomingInteractionModalContainer | IUIKitIncomingInteractionMessageContainer;
+}
+
+export interface IUIKitLivechatViewSubmitIncomingInteraction extends IUIKitLivechatBaseIncomingInteraction {
+    view: IUIKitView;
+    triggerId: string;
+}
+
+export interface IUIKitLivechatViewCloseIncomingInteraction extends IUIKitLivechatBaseIncomingInteraction {
+    view: IUIKitView;
+    isCleared: boolean;
+}

--- a/src/definition/uikit/livechat/UIKitLivechatInteractionContext.ts
+++ b/src/definition/uikit/livechat/UIKitLivechatInteractionContext.ts
@@ -1,7 +1,7 @@
 // tslint:disable:max-classes-per-file
 import { IUIKitBaseIncomingInteraction } from '../UIKitIncomingInteractionTypes';
 import { UIKitInteractionResponder } from '../UIKitInteractionResponder';
-import { IUIKitLivechatBaseIncomingInteraction, IUIKitLivechatBlockIncomingInteraction, IUIKitLivechatViewCloseIncomingInteraction, IUIKitLivechatViewSubmitIncomingInteraction } from './UIKitLivechatIncomingInteractionType';
+import { IUIKitLivechatBaseIncomingInteraction, IUIKitLivechatBlockIncomingInteraction } from './UIKitLivechatIncomingInteractionType';
 
 export abstract class UIKitLivechatInteractionContext {
     private baseContext: IUIKitLivechatBaseIncomingInteraction;
@@ -27,26 +27,6 @@ export class UIKitLivechatBlockInteractionContext extends UIKitLivechatInteracti
     }
 
     public getInteractionData(): IUIKitLivechatBlockIncomingInteraction {
-        return this.interactionData;
-    }
-}
-
-export class UIKitLivechatViewSubmitInteractionContext extends UIKitLivechatInteractionContext {
-    constructor(private readonly interactionData: IUIKitLivechatViewSubmitIncomingInteraction) {
-        super(interactionData);
-    }
-
-    public getInteractionData(): IUIKitLivechatViewSubmitIncomingInteraction {
-        return this.interactionData;
-    }
-}
-
-export class UIKitLivechatViewCloseInteractionContext extends UIKitLivechatInteractionContext {
-    constructor(private readonly interactionData: IUIKitLivechatViewCloseIncomingInteraction) {
-        super(interactionData);
-    }
-
-    public getInteractionData(): IUIKitLivechatViewCloseIncomingInteraction {
         return this.interactionData;
     }
 }

--- a/src/definition/uikit/livechat/UIKitLivechatInteractionContext.ts
+++ b/src/definition/uikit/livechat/UIKitLivechatInteractionContext.ts
@@ -1,0 +1,52 @@
+// tslint:disable:max-classes-per-file
+import { IUIKitBaseIncomingInteraction } from '../UIKitIncomingInteractionTypes';
+import { UIKitInteractionResponder } from '../UIKitInteractionResponder';
+import { IUIKitLivechatBaseIncomingInteraction, IUIKitLivechatBlockIncomingInteraction, IUIKitLivechatViewCloseIncomingInteraction, IUIKitLivechatViewSubmitIncomingInteraction } from './UIKitLivechatIncomingInteractionType';
+
+export abstract class UIKitLivechatInteractionContext {
+    private baseContext: IUIKitLivechatBaseIncomingInteraction;
+    private responder: UIKitInteractionResponder;
+    constructor(baseContext: IUIKitLivechatBaseIncomingInteraction) {
+        const { appId, actionId, room, visitor, triggerId } = baseContext;
+
+        this.baseContext = { appId, actionId, room, visitor, triggerId };
+
+        this.responder = new UIKitInteractionResponder(this.baseContext as any as IUIKitBaseIncomingInteraction);
+    }
+
+    public getInteractionResponder() {
+        return this.responder;
+    }
+
+    public abstract getInteractionData(): IUIKitLivechatBaseIncomingInteraction;
+}
+
+export class UIKitLivechatBlockInteractionContext extends UIKitLivechatInteractionContext {
+    constructor(private readonly interactionData: IUIKitLivechatBlockIncomingInteraction) {
+        super(interactionData);
+    }
+
+    public getInteractionData(): IUIKitLivechatBlockIncomingInteraction {
+        return this.interactionData;
+    }
+}
+
+export class UIKitLivechatViewSubmitInteractionContext extends UIKitLivechatInteractionContext {
+    constructor(private readonly interactionData: IUIKitLivechatViewSubmitIncomingInteraction) {
+        super(interactionData);
+    }
+
+    public getInteractionData(): IUIKitLivechatViewSubmitIncomingInteraction {
+        return this.interactionData;
+    }
+}
+
+export class UIKitLivechatViewCloseInteractionContext extends UIKitLivechatInteractionContext {
+    constructor(private readonly interactionData: IUIKitLivechatViewCloseIncomingInteraction) {
+        super(interactionData);
+    }
+
+    public getInteractionData(): IUIKitLivechatViewCloseIncomingInteraction {
+        return this.interactionData;
+    }
+}

--- a/src/definition/uikit/livechat/index.ts
+++ b/src/definition/uikit/livechat/index.ts
@@ -1,0 +1,4 @@
+export * from './IUIKitLivechatActionHandler';
+export * from './UIKitLivechatIncomingInteractionType';
+export * from './UIKitLivechatInteractionContext';
+export * from './IUIKitLivechatIncomingInteraction';

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -5,7 +5,7 @@ import { IMessage } from '../../definition/messages';
 import { AppInterface, AppMethod } from '../../definition/metadata';
 import { IRoom, IRoomUserJoinedContext } from '../../definition/rooms';
 import { IUIKitIncomingInteraction, IUIKitResponse, IUIKitView, UIKitIncomingInteractionType } from '../../definition/uikit';
-import { IUIKitLivechatIncomingInteraction, UIKitLivechatBlockInteractionContext, UIKitLivechatViewCloseInteractionContext, UIKitLivechatViewSubmitInteractionContext } from '../../definition/uikit/livechat';
+import { IUIKitLivechatIncomingInteraction, UIKitLivechatBlockInteractionContext } from '../../definition/uikit/livechat';
 import {
     IUIKitIncomingInteractionMessageContainer,
     IUIKitIncomingInteractionModalContainer,
@@ -863,10 +863,6 @@ export class AppListenerManager {
             switch (interactionType) {
                 case UIKitIncomingInteractionType.BLOCK:
                     return AppMethod.UIKIT_LIVECHAT_BLOCK_ACTION;
-                case UIKitIncomingInteractionType.VIEW_SUBMIT:
-                    return AppMethod.UIKIT_LIVECHAT_VIEW_SUBMIT;
-                case UIKitIncomingInteractionType.VIEW_CLOSED:
-                    return AppMethod.UIKIT_LIVECHAT_VIEW_CLOSE;
             }
         })(type);
 
@@ -899,30 +895,6 @@ export class AppListenerManager {
                         value,
                         message,
                         container: container as IUIKitIncomingInteractionModalContainer | IUIKitIncomingInteractionMessageContainer,
-                    });
-                }
-                case UIKitIncomingInteractionType.VIEW_SUBMIT: {
-                    const { view } = interactionData.payload as { view: IUIKitView };
-
-                    return new UIKitLivechatViewSubmitInteractionContext({
-                        appId,
-                        actionId,
-                        view,
-                        room,
-                        triggerId,
-                        visitor,
-                    });
-                }
-                case UIKitIncomingInteractionType.VIEW_CLOSED: {
-                    const { view, isCleared } = interactionData.payload as { view: IUIKitView, isCleared: boolean };
-
-                    return new UIKitLivechatViewCloseInteractionContext({
-                        appId,
-                        actionId,
-                        view,
-                        room,
-                        isCleared,
-                        visitor,
                     });
                 }
             }

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -5,6 +5,7 @@ import { IMessage } from '../../definition/messages';
 import { AppInterface, AppMethod } from '../../definition/metadata';
 import { IRoom, IRoomUserJoinedContext } from '../../definition/rooms';
 import { IUIKitIncomingInteraction, IUIKitResponse, IUIKitView, UIKitIncomingInteractionType } from '../../definition/uikit';
+import { IUIKitLivechatIncomingInteraction, UIKitLivechatBlockInteractionContext, UIKitLivechatViewCloseInteractionContext, UIKitLivechatViewSubmitInteractionContext } from '../../definition/uikit/livechat';
 import {
     IUIKitIncomingInteractionMessageContainer,
     IUIKitIncomingInteractionModalContainer,
@@ -29,6 +30,7 @@ type EventData = (
     IUser |
     ILivechatRoom |
     IUIKitIncomingInteraction |
+    IUIKitLivechatIncomingInteraction |
     IExternalComponent |
     ILivechatEventContext |
     IRoomUserJoinedContext |
@@ -186,6 +188,8 @@ export class AppListenerManager {
                 return;
             case AppInterface.IUIKitInteractionHandler:
                 return this.executeUIKitInteraction(data as IUIKitIncomingInteraction);
+            case AppInterface.IUIKitLivechatInteractionHandler:
+                return this.executeUIKitLivechatInteraction(data as IUIKitLivechatIncomingInteraction);
             // Livechat
             case AppInterface.IPostLivechatRoomStarted:
                 return this.executePostLivechatRoomStarted(data as ILivechatRoom);
@@ -838,6 +842,87 @@ export class AppListenerManager {
                         room,
                         isCleared,
                         user,
+                    });
+                }
+            }
+        })(type, data);
+
+        return app.call(method,
+            interactionContext,
+            this.am.getReader(appId),
+            this.am.getHttp(appId),
+            this.am.getPersistence(appId),
+            this.am.getModifier(appId),
+        );
+    }
+
+    private async executeUIKitLivechatInteraction(data: IUIKitLivechatIncomingInteraction): Promise<IUIKitResponse> {
+        const { appId, type } = data;
+
+        const method = ((interactionType: string) => {
+            switch (interactionType) {
+                case UIKitIncomingInteractionType.BLOCK:
+                    return AppMethod.UIKIT_LIVECHAT_BLOCK_ACTION;
+                case UIKitIncomingInteractionType.VIEW_SUBMIT:
+                    return AppMethod.UIKIT_LIVECHAT_VIEW_SUBMIT;
+                case UIKitIncomingInteractionType.VIEW_CLOSED:
+                    return AppMethod.UIKIT_LIVECHAT_VIEW_CLOSE;
+            }
+        })(type);
+
+        const app = this.manager.getOneById(appId);
+        if (!app.hasMethod(method)) {
+            return;
+        }
+
+        const interactionContext = ((interactionType: UIKitIncomingInteractionType, interactionData: IUIKitLivechatIncomingInteraction) => {
+            const {
+                actionId,
+                message,
+                visitor,
+                room,
+                triggerId,
+                container,
+            } = interactionData;
+
+            switch (interactionType) {
+                case UIKitIncomingInteractionType.BLOCK: {
+                    const { value, blockId } = interactionData.payload as { value: string; blockId: string };
+
+                    return new UIKitLivechatBlockInteractionContext({
+                        appId,
+                        actionId,
+                        blockId,
+                        visitor,
+                        room,
+                        triggerId,
+                        value,
+                        message,
+                        container: container as IUIKitIncomingInteractionModalContainer | IUIKitIncomingInteractionMessageContainer,
+                    });
+                }
+                case UIKitIncomingInteractionType.VIEW_SUBMIT: {
+                    const { view } = interactionData.payload as { view: IUIKitView };
+
+                    return new UIKitLivechatViewSubmitInteractionContext({
+                        appId,
+                        actionId,
+                        view,
+                        room,
+                        triggerId,
+                        visitor,
+                    });
+                }
+                case UIKitIncomingInteractionType.VIEW_CLOSED: {
+                    const { view, isCleared } = interactionData.payload as { view: IUIKitView, isCleared: boolean };
+
+                    return new UIKitLivechatViewCloseInteractionContext({
+                        appId,
+                        actionId,
+                        view,
+                        room,
+                        isCleared,
+                        visitor,
                     });
                 }
             }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Enables apps to listen to UIKit events that started in the livechat widget (for visitors)

# Why? :thinking:
<!--Additional explanation if needed-->
The current UIKit events required a `user` to be always present in the event context, which is not true for events triggered in the livechat widget - the `visitor` is not considered a fully authenticated user.

The new interfaces should allow apps to listen to those events without introducing breaking changes to the API.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
https://github.com/RocketChat/Rocket.Chat/pull/18706
This small app has been used for testing purposes https://github.com/d-gubert/conditional-block-test

# PS :eyes:
