### PR TITLE
[NEW][Omnichannel] add new events for onGuest and onRoom info save

### DIFF
--- a/src/definition/livechat/ILivechatEventContext.ts
+++ b/src/definition/livechat/ILivechatEventContext.ts
@@ -1,7 +1,9 @@
 import { IUser } from '../users';
 import { ILivechatRoom } from './ILivechatRoom';
+import {IVisitor} from './IVisitor';
 
 export interface ILivechatEventContext {
     agent: IUser;
     room: ILivechatRoom;
+    visitor?: IVisitor;
 }

--- a/src/definition/livechat/ILivechatEventContext.ts
+++ b/src/definition/livechat/ILivechatEventContext.ts
@@ -1,9 +1,7 @@
 import { IUser } from '../users';
 import { ILivechatRoom } from './ILivechatRoom';
-import {IVisitor} from './IVisitor';
 
 export interface ILivechatEventContext {
     agent: IUser;
     room: ILivechatRoom;
-    visitor?: IVisitor;
 }

--- a/src/definition/livechat/IPostLivechatGuestSaved.ts
+++ b/src/definition/livechat/IPostLivechatGuestSaved.ts
@@ -1,0 +1,21 @@
+import { IHttp, IModify, IPersistence, IRead } from '../accessors';
+import { AppMethod } from '../metadata';
+import { ILivechatEventContext } from './ILivechatEventContext';
+
+/**
+ * Handler called after the guest's info get saved.
+ */
+export interface IPostLivechatGuestSaved {
+    /**
+     * Handler called *after* the guest's info get saved.
+     *
+     * @param data the livechat context data which contains guest's info and room's info.
+     * @param read An accessor to the environment
+     * @param http An accessor to the outside world
+     * @param persis An accessor to the App's persistence
+     * @param modify An accessor to the modifier
+     */
+    [AppMethod.EXECUTE_POST_LIVECHAT_GUEST_SAVED](
+        context: ILivechatEventContext, read: IRead, http: IHttp, persis: IPersistence, modify?: IModify,
+    ): Promise<void>;
+}

--- a/src/definition/livechat/IPostLivechatGuestSaved.ts
+++ b/src/definition/livechat/IPostLivechatGuestSaved.ts
@@ -16,6 +16,6 @@ export interface IPostLivechatGuestSaved {
      * @param modify An accessor to the modifier
      */
     [AppMethod.EXECUTE_POST_LIVECHAT_GUEST_SAVED](
-        context: IVisitor, read: IRead, http: IHttp, persis: IPersistence, modify?: IModify,
+        context: IVisitor, read: IRead, http: IHttp, persis: IPersistence, modify: IModify,
     ): Promise<void>;
 }

--- a/src/definition/livechat/IPostLivechatGuestSaved.ts
+++ b/src/definition/livechat/IPostLivechatGuestSaved.ts
@@ -1,6 +1,6 @@
 import { IHttp, IModify, IPersistence, IRead } from '../accessors';
 import { AppMethod } from '../metadata';
-import { ILivechatEventContext } from './ILivechatEventContext';
+import { IVisitor } from './IVisitor';
 
 /**
  * Handler called after the guest's info get saved.
@@ -16,6 +16,6 @@ export interface IPostLivechatGuestSaved {
      * @param modify An accessor to the modifier
      */
     [AppMethod.EXECUTE_POST_LIVECHAT_GUEST_SAVED](
-        context: ILivechatEventContext, read: IRead, http: IHttp, persis: IPersistence, modify?: IModify,
+        context: IVisitor, read: IRead, http: IHttp, persis: IPersistence, modify?: IModify,
     ): Promise<void>;
 }

--- a/src/definition/livechat/IPostLivechatRoomSaved.ts
+++ b/src/definition/livechat/IPostLivechatRoomSaved.ts
@@ -16,6 +16,6 @@ export interface IPostLivechatRoomSaved {
      * @param modify An accessor to the modifier
      */
     [AppMethod.EXECUTE_POST_LIVECHAT_ROOM_SAVED](
-        context: ILivechatRoom, read: IRead, http: IHttp, persis: IPersistence, modify?: IModify,
+        context: ILivechatRoom, read: IRead, http: IHttp, persis: IPersistence, modify: IModify,
     ): Promise<void>;
 }

--- a/src/definition/livechat/IPostLivechatRoomSaved.ts
+++ b/src/definition/livechat/IPostLivechatRoomSaved.ts
@@ -1,0 +1,21 @@
+import { IHttp, IModify, IPersistence, IRead } from '../accessors';
+import { AppMethod } from '../metadata';
+import { ILivechatRoom } from './ILivechatRoom';
+
+/**
+ * Handler called after the room's info get saved.
+ */
+export interface IPostLivechatRoomSaved {
+    /**
+     * Handler called *after* the room's info get saved.
+     *
+     * @param data the livechat context data which contains room's info.
+     * @param read An accessor to the environment
+     * @param http An accessor to the outside world
+     * @param persis An accessor to the App's persistence
+     * @param modify An accessor to the modifier
+     */
+    [AppMethod.EXECUTE_POST_LIVECHAT_ROOM_SAVED](
+        context: ILivechatRoom, read: IRead, http: IHttp, persis: IPersistence, modify?: IModify,
+    ): Promise<void>;
+}

--- a/src/definition/livechat/index.ts
+++ b/src/definition/livechat/index.ts
@@ -9,6 +9,7 @@ import { IPostLivechatAgentAssigned } from './IPostLivechatAgentAssigned';
 import { IPostLivechatAgentUnassigned } from './IPostLivechatAgentUnassigned';
 import { IPostLivechatGuestSaved } from './IPostLivechatGuestSaved';
 import { IPostLivechatRoomClosed } from './IPostLivechatRoomClosed';
+import { IPostLivechatRoomSaved } from './IPostLivechatRoomSaved';
 import { IPostLivechatRoomStarted } from './IPostLivechatRoomStarted';
 import { IPostLivechatRoomTransferred } from './IPostLivechatRoomTransferred';
 import { IVisitor } from './IVisitor';
@@ -24,6 +25,7 @@ export {
     IPostLivechatGuestSaved,
     IPostLivechatRoomStarted,
     IPostLivechatRoomClosed,
+    IPostLivechatRoomSaved,
     IPostLivechatRoomTransferred,
     ILivechatRoomClosedHandler,
     ILivechatTransferData,

--- a/src/definition/livechat/index.ts
+++ b/src/definition/livechat/index.ts
@@ -7,6 +7,7 @@ import { ILivechatTransferData } from './ILivechatTransferData';
 import { ILivechatTransferEventContext, LivechatTransferEventType } from './ILivechatTransferEventContext';
 import { IPostLivechatAgentAssigned } from './IPostLivechatAgentAssigned';
 import { IPostLivechatAgentUnassigned } from './IPostLivechatAgentUnassigned';
+import { IPostLivechatGuestSaved } from './IPostLivechatGuestSaved';
 import { IPostLivechatRoomClosed } from './IPostLivechatRoomClosed';
 import { IPostLivechatRoomStarted } from './IPostLivechatRoomStarted';
 import { IPostLivechatRoomTransferred } from './IPostLivechatRoomTransferred';
@@ -20,6 +21,7 @@ export {
     ILivechatRoom,
     IPostLivechatAgentAssigned,
     IPostLivechatAgentUnassigned,
+    IPostLivechatGuestSaved,
     IPostLivechatRoomStarted,
     IPostLivechatRoomClosed,
     IPostLivechatRoomTransferred,

--- a/src/definition/metadata/AppInterface.ts
+++ b/src/definition/metadata/AppInterface.ts
@@ -35,4 +35,5 @@ export enum AppInterface {
     IPostLivechatAgentAssigned = 'IPostLivechatAgentAssigned',
     IPostLivechatAgentUnassigned = 'IPostLivechatAgentUnassigned',
     IPostLivechatRoomTransferred = 'IPostLivechatRoomTransferred',
+    IPostLivechatGuestSaved = 'IPostLivechatGuestSaved',
 }

--- a/src/definition/metadata/AppInterface.ts
+++ b/src/definition/metadata/AppInterface.ts
@@ -36,4 +36,5 @@ export enum AppInterface {
     IPostLivechatAgentUnassigned = 'IPostLivechatAgentUnassigned',
     IPostLivechatRoomTransferred = 'IPostLivechatRoomTransferred',
     IPostLivechatGuestSaved = 'IPostLivechatGuestSaved',
+    IPostLivechatRoomSaved = 'IPostLivechatRoomSaved',
 }

--- a/src/definition/metadata/AppMethod.ts
+++ b/src/definition/metadata/AppMethod.ts
@@ -64,4 +64,5 @@ export enum AppMethod {
     EXECUTE_POST_LIVECHAT_AGENT_UNASSIGNED = 'executePostLivechatAgentUnassigned',
     EXECUTE_POST_LIVECHAT_ROOM_TRANSFERRED = 'executePostLivechatRoomTransferred',
     EXECUTE_POST_LIVECHAT_GUEST_SAVED = 'executePostLivechatGuestSaved',
+    EXECUTE_POST_LIVECHAT_ROOM_SAVED = 'executePostLivechatRoomSaved',
 }

--- a/src/definition/metadata/AppMethod.ts
+++ b/src/definition/metadata/AppMethod.ts
@@ -63,4 +63,5 @@ export enum AppMethod {
     EXECUTE_POST_LIVECHAT_AGENT_ASSIGNED = 'executePostLivechatAgentAssigned',
     EXECUTE_POST_LIVECHAT_AGENT_UNASSIGNED = 'executePostLivechatAgentUnassigned',
     EXECUTE_POST_LIVECHAT_ROOM_TRANSFERRED = 'executePostLivechatRoomTransferred',
+    EXECUTE_POST_LIVECHAT_GUEST_SAVED = 'executePostLivechatGuestSaved',
 }

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -200,6 +200,8 @@ export class AppListenerManager {
                 return this.executeLivechatRoomClosedHandler(data as ILivechatRoom);
             case AppInterface.IPostLivechatRoomClosed:
                 return this.executePostLivechatRoomClosed(data as ILivechatRoom);
+            case AppInterface.IPostLivechatRoomSaved:
+                return this.executePostLivechatRoomSaved(data as ILivechatRoom);
             case AppInterface.IPostLivechatAgentAssigned:
                 return this.executePostLivechatAgentAssigned(data as ILivechatEventContext);
             case AppInterface.IPostLivechatAgentUnassigned:
@@ -1042,6 +1044,25 @@ export class AppListenerManager {
             }
 
             await app.call(AppMethod.EXECUTE_POST_LIVECHAT_GUEST_SAVED,
+                           cfLivechatRoom,
+                           this.am.getReader(appId),
+                           this.am.getHttp(appId),
+                           this.am.getPersistence(appId),
+                          );
+        }
+    }
+
+    private async executePostLivechatRoomSaved(data: ILivechatRoom): Promise<void> {
+        const cfLivechatRoom = Utilities.deepCloneAndFreeze(data);
+
+        for (const appId of this.listeners.get(AppInterface.IPostLivechatRoomSaved)) {
+            const app = this.manager.getOneById(appId);
+
+            if (!app.hasMethod(AppMethod.EXECUTE_POST_LIVECHAT_ROOM_SAVED)) {
+                continue;
+            }
+
+            await app.call(AppMethod.EXECUTE_POST_LIVECHAT_ROOM_SAVED,
                            cfLivechatRoom,
                            this.am.getReader(appId),
                            this.am.getHttp(appId),

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -1,6 +1,6 @@
 import { EssentialAppDisabledException } from '../../definition/exceptions';
 import { IExternalComponent } from '../../definition/externalComponent';
-import { ILivechatEventContext, ILivechatRoom, ILivechatTransferEventContext } from '../../definition/livechat';
+import { ILivechatEventContext, ILivechatRoom, ILivechatTransferEventContext, IVisitor } from '../../definition/livechat';
 import { IMessage } from '../../definition/messages';
 import { AppInterface, AppMethod } from '../../definition/metadata';
 import { IRoom, IRoomUserJoinedContext } from '../../definition/rooms';
@@ -28,6 +28,7 @@ type EventData = (
     IMessage |
     IRoom |
     IUser |
+    IVisitor |
     ILivechatRoom |
     IUIKitIncomingInteraction |
     IUIKitLivechatIncomingInteraction |
@@ -209,7 +210,7 @@ export class AppListenerManager {
             case AppInterface.IPostLivechatRoomTransferred:
                 return this.executePostLivechatRoomTransferred(data as ILivechatTransferEventContext);
             case AppInterface.IPostLivechatGuestSaved:
-                return this.executePostLivechatGuestSaved(data as ILivechatEventContext);
+                return this.executePostLivechatGuestSaved(data as IVisitor);
             default:
                 console.warn('An invalid listener was called');
                 return;
@@ -1033,7 +1034,7 @@ export class AppListenerManager {
         }
     }
 
-    private async executePostLivechatGuestSaved(data: ILivechatEventContext): Promise<void> {
+    private async executePostLivechatGuestSaved(data: IVisitor): Promise<void> {
         const cfLivechatRoom = Utilities.deepCloneAndFreeze(data);
 
         for (const appId of this.listeners.get(AppInterface.IPostLivechatGuestSaved)) {

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -1048,6 +1048,7 @@ export class AppListenerManager {
                            this.am.getReader(appId),
                            this.am.getHttp(appId),
                            this.am.getPersistence(appId),
+                           this.am.getModifier(appId),
                           );
         }
     }
@@ -1067,6 +1068,7 @@ export class AppListenerManager {
                            this.am.getReader(appId),
                            this.am.getHttp(appId),
                            this.am.getPersistence(appId),
+                           this.am.getModifier(appId),
                           );
         }
     }

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -206,6 +206,8 @@ export class AppListenerManager {
                 return this.executePostLivechatAgentUnassigned(data as ILivechatEventContext);
             case AppInterface.IPostLivechatRoomTransferred:
                 return this.executePostLivechatRoomTransferred(data as ILivechatTransferEventContext);
+            case AppInterface.IPostLivechatGuestSaved:
+                return this.executePostLivechatGuestSaved(data as ILivechatEventContext);
             default:
                 console.warn('An invalid listener was called');
                 return;
@@ -1027,6 +1029,24 @@ export class AppListenerManager {
                 this.am.getModifier(appId),
             );
         }
+    }
 
+    private async executePostLivechatGuestSaved(data: ILivechatEventContext): Promise<void> {
+        const cfLivechatRoom = Utilities.deepCloneAndFreeze(data);
+
+        for (const appId of this.listeners.get(AppInterface.IPostLivechatGuestSaved)) {
+            const app = this.manager.getOneById(appId);
+
+            if (!app.hasMethod(AppMethod.EXECUTE_POST_LIVECHAT_GUEST_SAVED)) {
+                continue;
+            }
+
+            await app.call(AppMethod.EXECUTE_POST_LIVECHAT_GUEST_SAVED,
+                           cfLivechatRoom,
+                           this.am.getReader(appId),
+                           this.am.getHttp(appId),
+                           this.am.getPersistence(appId),
+                          );
+        }
     }
 }


### PR DESCRIPTION
# What? :boat:
Added new interfaces to give the apps support to catch events when an omnichannel's guest have their information updated. Same for when the room gets its info updated.
<!--
- Added x;
- Updated y;
- Removed z.
-->

# Why? :thinking:
To solve the issue https://github.com/RocketChat/Rocket.Chat.Apps-engine/issues/270

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
