### PR TITLE
Remove file-type detection on upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -195,11 +195,6 @@
         "through2": "^2.0.3"
       }
     },
-    "@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
-    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -214,11 +209,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/debug": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/fancy-log": {
       "version": "1.3.0",
@@ -3259,17 +3249,6 @@
         "object-assign": "^4.0.1"
       }
     },
-    "file-type": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-15.0.1.tgz",
-      "integrity": "sha512-0LieQlSA3bWUdErNrxzxfI4rhsvNAVPBO06R8pTc1hp9SE6nhqlVyvhcaXoMmtXkBTPnQenbMPLW9X76hH76oQ==",
-      "requires": {
-        "readable-web-to-node-stream": "^2.0.0",
-        "strtok3": "^6.0.3",
-        "token-types": "^2.0.0",
-        "typedarray-to-buffer": "^3.1.5"
-      }
-    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -4443,7 +4422,8 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.7",
@@ -4843,11 +4823,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -6353,11 +6328,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "peek-readable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
-      "integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA=="
-    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -6692,11 +6662,6 @@
         "string_decoder": "~1.0.3",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "readable-web-to-node-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
-      "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
     },
     "recast": {
       "version": "0.10.43",
@@ -7617,16 +7582,6 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "strtok3": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.4.tgz",
-      "integrity": "sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==",
-      "requires": {
-        "@tokenizer/token": "^0.1.1",
-        "@types/debug": "^4.1.5",
-        "peek-readable": "^3.1.0"
-      }
-    },
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -8039,15 +7994,6 @@
         "through2": "^2.0.3"
       }
     },
-    "token-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
-      "integrity": "sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==",
-      "requires": {
-        "@tokenizer/token": "^0.1.0",
-        "ieee754": "^1.1.13"
-      }
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -8170,14 +8116,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "typedoc": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
   "dependencies": {
     "adm-zip": "^0.4.9",
     "cryptiles": "^4.1.3",
-    "file-type": "^15.0.1",
     "lodash.clonedeep": "^4.5.0",
     "semver": "^5.5.0",
     "stack-trace": "0.0.10",

--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.18.0-alpha",
+  "version": "1.18.0-beta",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",

--- a/src/server/accessors/UploadCreator.ts
+++ b/src/server/accessors/UploadCreator.ts
@@ -1,5 +1,3 @@
-import * as FileType from 'file-type';
-
 import { IUploadCreator } from '../../definition/accessors';
 import { IUpload } from '../../definition/uploads';
 import { IUploadDescriptor } from '../../definition/uploads/IUploadDescriptor';
@@ -18,12 +16,9 @@ export class UploadCreator implements IUploadCreator {
             descriptor.user = await this.bridges.getUserBridge().getAppUser(this.appId);
         }
 
-        const detectedFileType = await FileType.fromBuffer(buffer);
-
         const details = {
             name: descriptor.filename,
             size: buffer.length,
-            type: detectedFileType.mime,
             rid: descriptor.room.id,
             userId: descriptor.user && descriptor.user.id,
         } as IUploadDetails;


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Remove file type detection in the upload bridge

# Why? :thinking:
<!--Additional explanation if needed-->
The Rocket.Chat repo already has access to the libraries used to do so, and by removing this from the Apps-Engine, we keep things here as simple as possible

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
