### PR TITLE
[NEW] Add support for the "encoding" option in HTTP requests

### DIFF
--- a/src/definition/accessors/IHttp.ts
+++ b/src/definition/accessors/IHttp.ts
@@ -40,6 +40,14 @@ export interface IHttpRequest {
     };
     timeout?: number;
     /**
+     * The encoding to be used on response data.
+     *
+     * If null, the body is returned as a Buffer. Anything else (including the default value of undefined)
+     * will be passed as the encoding parameter to toString() (meaning this is effectively 'utf8' by default).
+     * (Note: if you expect binary data, you should set encoding: null.)
+     */
+    encoding?: string | null;
+    /**
      * if `true`, requires SSL certificates be valid.
      *
      * Defaul: `true`;


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Add a new optional property `encoding` to the interface IHttpRequest

# Why? :thinking:
<!--Additional explanation if needed-->
Make sure we can using `http.get` to download binary data correctly.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
https://open.rocket.chat/group/t9xgtnadgqwf3xkzh?msg=x5EsHiqtzv7rJj3qR (Private)

# PS :eyes:
The PR on the RocketChat side: https://github.com/RocketChat/Rocket.Chat/pull/19002