### PR TITLE
Remove doc generation from pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
   "pre-push": [
     "lint",
     "compile",
-    "unit-tests",
-    "gen-doc"
+    "unit-tests"
   ]
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Refer to title 😬 
# Why? :thinking:
<!--Additional explanation if needed-->
This is being more of a hassle than helpful as ALL doc files are updated and are not pushed at the same time with the code. We need to review the workflow around this.
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
