### PR TITLE
[IMPROVEMENT] Allow longer vm.runInContext timeout in debug mode

### DIFF
--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -62,7 +62,14 @@ export class ProxiedApp implements IApp {
     }
 
     public runInContext(codeToRun: string, context: vm.Context): any {
-        return vm.runInContext(codeToRun, context, { timeout: 1000 });
+        const argv = process.execArgv.join('');
+
+        let timeout = 1000;
+        if (argv.includes('inspect') || argv.includes('debug')) {
+            timeout = 1000 * 3600;
+        }
+
+        return vm.runInContext(codeToRun, context, { timeout });
     }
 
     public async call(method: AppMethod, ...args: Array<any>): Promise<any> {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
It will use a different `timeout` (3600 * 1000 ms instead of 1000 ms) when you start a RocketChat instance with `meteor npm run debug` instead of `meteor` or `meteor npm start`. This change will make debugging workflow more convenient (such as adding breakpoints in the apps-engine or Rocket.Chat).

# Why? :thinking:
<!--Additional explanation if needed-->

Originally, if you add a breakpoint inside a RocketChat ap or apps-engine, it might throw an error since vm.runInContext timeout might be over 1000 ms. Thereby, it makes debugging difficult to be continued.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
