### PR TITLE
Add the scheduler modifier to the configurationModify object

### DIFF
--- a/src/definition/accessors/IConfigurationModify.ts
+++ b/src/definition/accessors/IConfigurationModify.ts
@@ -1,3 +1,4 @@
+import { ISchedulerModify } from './ISchedulerModify';
 import { IServerSettingsModify } from './IServerSettingsModify';
 import { ISlashCommandsModify } from './ISlashCommandsModify';
 
@@ -11,4 +12,7 @@ export interface IConfigurationModify {
 
     /** Accessor for modifying the slash commands inside of Rocket.Chat. */
     readonly slashCommands: ISlashCommandsModify;
+
+    /** Accessor for modifying schedulers */
+    readonly scheduler: ISchedulerModify;
 }

--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.19.0",
+  "version": "1.20.0-alpha",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",

--- a/src/server/accessors/ConfigurationModify.ts
+++ b/src/server/accessors/ConfigurationModify.ts
@@ -1,15 +1,14 @@
 import {
     IConfigurationModify,
+    ISchedulerModify,
     IServerSettingsModify,
     ISlashCommandsModify,
 } from '../../definition/accessors';
 
 export class ConfigurationModify implements IConfigurationModify {
-    public readonly serverSettings: IServerSettingsModify;
-    public readonly slashCommands: ISlashCommandsModify;
-
-    constructor(sets: IServerSettingsModify, cmds: ISlashCommandsModify) {
-        this.serverSettings = sets;
-        this.slashCommands = cmds;
-    }
+    constructor(
+        public readonly serverSettings: IServerSettingsModify,
+        public readonly slashCommands: ISlashCommandsModify,
+        public readonly scheduler: ISchedulerModify,
+    ) { }
 }

--- a/src/server/managers/AppAccessorManager.ts
+++ b/src/server/managers/AppAccessorManager.ts
@@ -26,6 +26,7 @@ import {
     Reader,
     RoomRead,
     SchedulerExtend,
+    SchedulerModify,
     ServerSettingRead,
     ServerSettingsModify,
     SettingRead,
@@ -115,10 +116,11 @@ export class AppAccessorManager {
 
     public getConfigurationModify(appId: string): IConfigurationModify {
         if (!this.configModifiers.has(appId)) {
-            const sets = new ServerSettingsModify(this.bridges.getServerSettingBridge(), appId);
-            const cmds = new SlashCommandsModify(this.manager.getCommandManager(), appId);
-
-            this.configModifiers.set(appId, new ConfigurationModify(sets, cmds));
+            this.configModifiers.set(appId, new ConfigurationModify(
+                new ServerSettingsModify(this.bridges.getServerSettingBridge(), appId),
+                new SlashCommandsModify(this.manager.getCommandManager(), appId),
+                new SchedulerModify(this.bridges.getSchedulerBridge(), appId),
+            ));
         }
 
         return this.configModifiers.get(appId);

--- a/tests/server/accessors/ConfigurationModify.spec.ts
+++ b/tests/server/accessors/ConfigurationModify.spec.ts
@@ -1,23 +1,25 @@
 import { Expect, SetupFixture, Test } from 'alsatian';
-import { IServerSettingsModify, ISlashCommandsModify } from '../../../src/definition/accessors';
+import { ISchedulerModify, IServerSettingsModify, ISlashCommandsModify } from '../../../src/definition/accessors';
 
 import { ConfigurationModify } from '../../../src/server/accessors';
 
 export class ConfigurationExtendTestFixture {
     private ssm: IServerSettingsModify;
     private scm: ISlashCommandsModify;
+    private scheduler: ISchedulerModify;
 
     @SetupFixture
     public setupFixture() {
         this.ssm = {} as IServerSettingsModify;
         this.scm = {} as ISlashCommandsModify;
+        this.scheduler = {} as ISchedulerModify;
     }
 
     @Test()
     public useConfigurationModify() {
-        Expect(() => new ConfigurationModify(this.ssm, this.scm)).not.toThrow();
+        Expect(() => new ConfigurationModify(this.ssm, this.scm, this.scheduler)).not.toThrow();
 
-        const sm = new ConfigurationModify(this.ssm, this.scm);
+        const sm = new ConfigurationModify(this.ssm, this.scm, this.scheduler);
         Expect(sm.serverSettings).toBeDefined();
         Expect(sm.slashCommands).toBeDefined();
     }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Adds the `ISchedulerModify` interface as a member of `IConfigurationModify`

# Why? :thinking:
<!--Additional explanation if needed-->
This allows apps to control scheduled jobs from events that don't have access to the `IModify`

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
