### PR TITLE
[FIX] Apps were being disabled during RC server startup

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -202,7 +202,7 @@ export class AppManager {
                 continue;
             }
 
-            await this.initializeApp(items.get(rl.getID()), rl, true).catch(console.error);
+            await this.initializeApp(items.get(rl.getID()), rl, false, true).catch(console.error);
         }
 
         // Let's ensure the required settings are all set


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Don't store changes in the apps' statuses during server startup

# Why? :thinking:
<!--Additional explanation if needed-->
During startup, all apps state are set to `initializing` as part of the load process. At the end of the process, the apps' status are set to the value that was before `initilizing`, which is stored at `ProxiedApp`'s `previousStatus` property.

But when in a HA environment, all servers write this information to the same document, making `previousStatus` from the `ProxiedApp` and the actual status stored in the database both as `initializing` because multiple writes were done, thus not setting the correct state as `enabled` or `disabled`. This causes the some apps' states to appear as `disabled` in the apps' list. Not storing those changes in the state of the app during startup fixes this issue.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
