### PR TITLE
[FIX] Missing a method to allow messages' updates within the MessageBuilder (#343)

### DIFF
--- a/src/definition/accessors/IMessageBuilder.ts
+++ b/src/definition/accessors/IMessageBuilder.ts
@@ -13,12 +13,21 @@ export interface IMessageBuilder {
     kind: RocketChatAssociationModel.MESSAGE;
 
     /**
-     * Provides a convient way to set the data for the message.
+     * Provides a convenient way to set the data for the message.
      * Note: Providing an "id" field here will be ignored.
      *
      * @param message the message data to set
      */
     setData(message: IMessage): IMessageBuilder;
+
+    /**
+     * Provides a convenient way to set the data for the message
+     * keeping the "id" field so as to update the message later.
+     *
+     * @param message the message data to set
+     * @param editor the user who edited the updated message
+     */
+    setUpdateData(message: IMessage, editor: IUser): IMessageBuilder;
 
     /**
      * Sets the thread to which this message belongs, if any.

--- a/src/server/accessors/MessageBuilder.ts
+++ b/src/server/accessors/MessageBuilder.ts
@@ -21,6 +21,13 @@ export class MessageBuilder implements IMessageBuilder {
         return this;
     }
 
+    public setUpdateData(data: IMessage, editor: IUser): IMessageBuilder {
+        this.msg = data;
+        this.msg.editor = editor;
+
+        return this;
+    }
+
     public setThreadId(threadId: string): IMessageBuilder {
         this.msg.threadId = threadId;
 

--- a/src/server/accessors/MessageBuilder.ts
+++ b/src/server/accessors/MessageBuilder.ts
@@ -24,6 +24,8 @@ export class MessageBuilder implements IMessageBuilder {
     public setUpdateData(data: IMessage, editor: IUser): IMessageBuilder {
         this.msg = data;
         this.msg.editor = editor;
+        this.msg.updatedAt = new Date();
+        this.msg.editedAt = this.msg.updatedAt;
 
         return this;
     }

--- a/src/server/accessors/MessageBuilder.ts
+++ b/src/server/accessors/MessageBuilder.ts
@@ -24,8 +24,7 @@ export class MessageBuilder implements IMessageBuilder {
     public setUpdateData(data: IMessage, editor: IUser): IMessageBuilder {
         this.msg = data;
         this.msg.editor = editor;
-        this.msg.updatedAt = new Date();
-        this.msg.editedAt = this.msg.updatedAt;
+        this.msg.editedAt = new Date();
 
         return this;
     }

--- a/tests/server/accessors/MessageBuilder.spec.ts
+++ b/tests/server/accessors/MessageBuilder.spec.ts
@@ -1,9 +1,9 @@
 import { Expect, Test } from 'alsatian';
 import { IMessage } from '../../../src/definition/messages';
 import { TestData } from '../../test-data/utilities';
+import { IUser } from '../../../src/definition/users';
 
 import { MessageBuilder, UserBuilder } from '../../../src/server/accessors';
-import { IUser } from '../../../src/definition/users';
 
 export class MessageBuilderAccessorTestFixture {
     @Test()

--- a/tests/server/accessors/MessageBuilder.spec.ts
+++ b/tests/server/accessors/MessageBuilder.spec.ts
@@ -1,7 +1,7 @@
 import { Expect, Test } from 'alsatian';
 import { IMessage } from '../../../src/definition/messages';
-import { TestData } from '../../test-data/utilities';
 import { IUser } from '../../../src/definition/users';
+import { TestData } from '../../test-data/utilities';
 
 import { MessageBuilder, UserBuilder } from '../../../src/server/accessors';
 

--- a/tests/server/accessors/MessageBuilder.spec.ts
+++ b/tests/server/accessors/MessageBuilder.spec.ts
@@ -2,7 +2,8 @@ import { Expect, Test } from 'alsatian';
 import { IMessage } from '../../../src/definition/messages';
 import { TestData } from '../../test-data/utilities';
 
-import { MessageBuilder } from '../../../src/server/accessors';
+import { MessageBuilder, UserBuilder } from '../../../src/server/accessors';
+import { IUser } from '../../../src/definition/users';
 
 export class MessageBuilderAccessorTestFixture {
     @Test()
@@ -18,6 +19,16 @@ export class MessageBuilderAccessorTestFixture {
         // setData just replaces the passed in object, so let's treat it differently
         Expect(mbOnce.setData({text: 'hello' } as IMessage)).toBe(mbOnce);
         Expect((mbOnce as any).msg.text).toBe('hello');
+
+        const mbUpdate = new MessageBuilder();
+        const editor = new UserBuilder();
+        editor.setUsername('username');
+        editor.setDisplayName('name');
+
+        // setUpdateData keeps the ID passed in the message object, so let's treat it differently
+        Expect(mbUpdate.setUpdateData({text: 'hello', id: 'messageID' } as IMessage, editor.getUser() as IUser)).toBe(mbUpdate);
+        Expect((mbUpdate as any).msg.text).toBe('hello');
+        Expect((mbUpdate as any).msg.id).toBe('messageID');
 
         const msg: IMessage = {} as IMessage;
         const mb = new MessageBuilder(msg);


### PR DESCRIPTION
# What? :boat:
 - Added the **`setUpdateData` method** in the `MessageBuilder`. This method is similar to the `setData` method, but it does not delete the message's ID (hence, it is possible to use the `ModifyUpdater` object to update the message later using the `messageBuilder`).

# Why? :thinking:
The `setUpdateData` method is introduced in order to allow messages' updates within the `messageBuilder` object. It has been built as a solution to the issue #343.

# Links :earth_americas:
[Issue #343](https://github.com/RocketChat/Rocket.Chat.Apps-engine/issues/343)

# PS :eyes:
The editor (user who updated the message) is also a mandatory parameter from the `setUpdateData` method, since this attribute is necessary in updates.