### PR TITLE
[FIX] Add exception to the addition of keys that contain periods

### DIFF
--- a/src/server/accessors/MessageExtender.ts
+++ b/src/server/accessors/MessageExtender.ts
@@ -24,6 +24,10 @@ export class MessageExtender implements IMessageExtender {
             throw new Error(`The message already contains a custom field by the key: ${ key }`);
         }
 
+        if (key.includes('.')) {
+            throw new Error(`The given key contains a period, which is not allowed. Key: ${ key }`);
+        }
+
         this.msg.customFields[key] = value;
 
         return this;

--- a/src/server/accessors/RoomExtender.ts
+++ b/src/server/accessors/RoomExtender.ts
@@ -23,6 +23,10 @@ export class RoomExtender implements IRoomExtender {
             throw new Error(`The room already contains a custom field by the key: ${ key }`);
         }
 
+        if (key.includes('.')) {
+            throw new Error(`The given key contains a period, which is not allowed. Key: ${ key }`);
+        }
+
         this.room.customFields[key] = value;
 
         return this;

--- a/tests/server/accessors/MessageExtender.spec.ts
+++ b/tests/server/accessors/MessageExtender.spec.ts
@@ -22,6 +22,7 @@ export class MessageExtenderAccessorTestFixture {
         Expect(msg.customFields).toBeDefined();
         Expect(msg.customFields.thing).toBe('value');
         Expect(() => me.addCustomField('thing', 'second')).toThrowError(Error, 'The message already contains a custom field by the key: thing');
+        Expect(() => me.addCustomField('thing.', 'second')).toThrowError(Error, 'The given key contains a period, which is not allowed. Key: thing.');
 
         Expect(me.addAttachment({})).toBe(me);
         Expect(msg.attachments.length).toBe(1);

--- a/tests/server/accessors/RoomExtender.spec.ts
+++ b/tests/server/accessors/RoomExtender.spec.ts
@@ -21,6 +21,7 @@ export class RoomExtenderAccessorTestFixture {
         Expect(room.customFields).toBeDefined();
         Expect(room.customFields.thing as any).toBe('value');
         Expect(() => re.addCustomField('thing', 'second')).toThrowError(Error, 'The room already contains a custom field by the key: thing');
+        Expect(() => re.addCustomField('thing.', 'second')).toThrowError(Error, 'The given key contains a period, which is not allowed. Key: thing.');
 
         Expect(room.usernames).not.toBeDefined();
         Expect(re.addMember(TestData.getUser('theId', 'bradley'))).toBe(re);


### PR DESCRIPTION
# What? :boat:
- Added exceptions in the `addCustomField` methods in the `MessageExtender` and `RoomExtender` classes when the key to be added contains a period.

# Why? :thinking:
The added exceptions were described in the `addCustomField` method's documentation (description) from both classes, but were not really implemented in their code.

# Links :earth_americas:

# PS :eyes:
