### PR TITLE
[FIX] Add exception to the update of required settings with empty values

### DIFF
--- a/src/server/managers/AppSettingsManager.ts
+++ b/src/server/managers/AppSettingsManager.ts
@@ -37,6 +37,10 @@ export class AppSettingsManager {
             throw new Error('No setting found for the App by the provided id.');
         }
 
+        if (setting.value == null && rl.getStorageItem().settings[setting.id].required) {
+            throw new Error('No value given to required field.');
+        }
+
         setting.updatedAt = new Date();
         rl.getStorageItem().settings[setting.id] = setting;
 

--- a/tests/server/managers/AppSettingsManager.spec.ts
+++ b/tests/server/managers/AppSettingsManager.spec.ts
@@ -120,6 +120,11 @@ export class AppSettingsManagerTestFixture {
         const set = TestData.getSetting('testing');
         await Expect(async () => await asm.updateAppSetting('testing', set)).not.toThrowAsync();
 
+        const setRequired = set;
+        setRequired.value = null;
+        setRequired.required = true;
+        await Expect(async () => await asm.updateAppSetting('testing', setRequired)).toThrowErrorAsync(Error, 'No value given to required field.');
+
         Expect(this.mockStorage.update).toHaveBeenCalledWith(this.mockStorageItem).exactly(1);
         Expect(this.mockApp.setStorageItem).toHaveBeenCalledWith(this.mockStorageItem).exactly(1);
         Expect(this.mockBridges.getAppDetailChangesBridge().onAppSettingsChange).toHaveBeenCalledWith('testing', set).exactly(1);


### PR DESCRIPTION
# What? :boat:
 - Add an exception when the user attempts to update a **required** app settings' field with an empty value. Thus, required settings will not accept empty values given in the UI.

# Why? :thinking:
This PR fixes this [issue](https://app.clickup.com/t/98bbyn) on Apps Engine's side.

# Links :earth_americas:
[Issue - ClickUp](https://app.clickup.com/t/98bbyn).

# PS :eyes: