### PR TITLE
[FIX] Add deprecation notices to all instances of the getAppUserUsername method

### DIFF
--- a/src/definition/IApp.ts
+++ b/src/definition/IApp.ts
@@ -30,7 +30,7 @@ export interface IApp {
      * Gets the username of this App's app user.
      *
      * @return {string} the username of the app user
-     * 
+     *
      * @deprecated This method will be removed in the next major version.
      * Please use read.getAppUser instead.
      */

--- a/src/definition/IApp.ts
+++ b/src/definition/IApp.ts
@@ -30,6 +30,9 @@ export interface IApp {
      * Gets the username of this App's app user.
      *
      * @return {string} the username of the app user
+     * 
+     * @deprecated This method will be removed in the next major version.
+     * Please use read.getAppUser instead.
      */
     getAppUserUsername(): string;
 


### PR DESCRIPTION
# What? :boat:
 - Add missing deprecation notice to the `getAppUserUsername` method in the `IApp` interface.

# Why? :thinking:
The deprecation notice must be added since the `getAppUserUsername` method is planned to be removed in the next major version.

# Links :earth_americas:
[Task - ClickUp](https://app.clickup.com/t/98bbwe)

# PS :eyes: