### PR TITLE
[IMPROVEMENT] Make the parameter on the getAppUser method optional

### DIFF
--- a/src/definition/accessors/IUserRead.ts
+++ b/src/definition/accessors/IUserRead.ts
@@ -12,5 +12,5 @@ export interface IUserRead {
     /**
      * Gets the app user of this app.
      */
-    getAppUser(appId: string): Promise<IUser | undefined>;
+    getAppUser(appId?: string): Promise<IUser | undefined>;
 }

--- a/src/server/accessors/UserRead.ts
+++ b/src/server/accessors/UserRead.ts
@@ -13,11 +13,7 @@ export class UserRead implements IUserRead {
         return this.userBridge.getByUsername(username, this.appId);
     }
 
-    public getAppUser(appId?: string): Promise<IUser | undefined> {
-        if (appId === undefined) {
-            appId = this.appId;
-        }
-
+    public getAppUser(appId: string = this.appId): Promise<IUser | undefined> {
         return this.userBridge.getAppUser(appId);
     }
 }

--- a/src/server/accessors/UserRead.ts
+++ b/src/server/accessors/UserRead.ts
@@ -13,7 +13,11 @@ export class UserRead implements IUserRead {
         return this.userBridge.getByUsername(username, this.appId);
     }
 
-    public getAppUser(appId: string): Promise<IUser | undefined> {
+    public getAppUser(appId?: string): Promise<IUser | undefined> {
+        if (appId === undefined) {
+            appId = this.appId;
+        }
+
         return this.userBridge.getAppUser(appId);
     }
 }

--- a/src/server/bridges/IUserBridge.ts
+++ b/src/server/bridges/IUserBridge.ts
@@ -5,7 +5,7 @@ export interface IUserBridge {
 
     getByUsername(username: string, appId: string): Promise<IUser>;
 
-    getAppUser(appId: string): Promise<IUser | undefined>;
+    getAppUser(appId?: string): Promise<IUser | undefined>;
 
     getActiveUserCount(): Promise<number>;
 

--- a/tests/server/accessors/UserRead.spec.ts
+++ b/tests/server/accessors/UserRead.spec.ts
@@ -22,7 +22,7 @@ export class UserReadAccessorTestFixture {
             getByUsername(id, appId): Promise<IUser> {
                 return Promise.resolve(theUser);
             },
-            getAppUser(appId: string): Promise<IUser> {
+            getAppUser(appId?: string): Promise<IUser> {
                 return Promise.resolve(theUser);
             },
         } as IUserBridge;
@@ -42,5 +42,6 @@ export class UserReadAccessorTestFixture {
 
         Expect(await ur.getAppUser(this.mockAppId)).toBeDefined();
         Expect(await ur.getAppUser(this.mockAppId)).toEqual(this.user);
+        Expect(await ur.getAppUser()).toEqual(this.user);
     }
 }

--- a/tests/test-data/bridges/userBridge.ts
+++ b/tests/test-data/bridges/userBridge.ts
@@ -23,7 +23,7 @@ export class TestsUserBridge implements IUserBridge {
         throw new Error('Method not implemented.');
     }
 
-    public getAppUser(appId: string): Promise<IUser> {
+    public getAppUser(appId?: string): Promise<IUser> {
         throw new Error('Method not implemented.');
     }
 


### PR DESCRIPTION
# What? :boat:
 - Updated all instances of the `getAppUser` method so as to make the `appId` parameter optional.

# Why? :thinking:
This PR implements the changes described in this [task](https://app.clickup.com/t/98bbwg), and moves closer to completely removing the `getAppUser` method's parameter in the near future.

# Links :earth_americas:
[Task - ClickUp](https://app.clickup.com/t/98bbwg)

# PS :eyes: