### PR TITLE
Permissions review

### DIFF
--- a/src/server/compiler/modules/net.ts
+++ b/src/server/compiler/modules/net.ts
@@ -15,10 +15,10 @@ export const netModuleHandler = (appId: string): ProxyHandler<typeof net> => ({
             throw new ForbiddenNativeModuleAccess('net', prop);
         }
 
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.networking.general)) {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions.networking.default)) {
             throw new PermissionDeniedError({
                 appId,
-                missingPermissions: [AppPermissions.networking.general],
+                missingPermissions: [AppPermissions.networking.default],
                 methodName: `net.${prop}`,
             });
         }

--- a/src/server/permissions/AppPermissions.ts
+++ b/src/server/permissions/AppPermissions.ts
@@ -14,56 +14,72 @@ import { INetworkingPermission, IPermission } from '../../definition/permissions
  *
  * @example
  *
- * AppPermissions.http.general // { name: 'http.general', domains: [] }
+ * AppPermissions.upload.read // { name: 'upload.read', domains: [] }
  */
 export const AppPermissions = {
-    user: {
+    'user': {
         read: { name: 'user.read' },
         write: { name: 'user.write' },
     },
-    upload: {
+    'upload': {
         read: { name: 'upload.read' },
         write: { name: 'upload.write' },
     },
-    ui: {
-        interaction: { name: 'ui.interaction' },
+    'ui': {
+        interaction: { name: 'ui.interact' },
     },
-    setting: {
+    'setting': {
         read: { name: 'server-setting.read' },
         write: { name: 'server-setting.write' },
     },
-    scheduler: {
-        general: { name: 'scheduler.general' },
-    },
-    room: {
+    'room': {
         read: { name: 'room.read' },
         write: { name: 'room.write' },
     },
-    persistence: {
-        read: { name: 'persistence.read' },
-        write: { name: 'persistence.write' },
-    },
-    message: {
+    'message': {
         read: { name: 'message.read' },
         write: { name: 'message.write' },
-        notification: { name: 'message.notification' },
     },
-    livechat: {
-        read: { name: 'livechat.read' },
-        write: { name: 'livechat.write' },
+    'livechat-status': {
+        read: { name: 'livechat-status.read' },
     },
-    networking: {
-        general: { name: 'networking.general', domains: [] } as INetworkingPermission,
+    'livechat-custom-fields': {
+        write: { name: 'livechat-custom-fields.write' },
     },
-    env: {
+    'livechat-visitor': {
+        read: { name: 'livechat-visitor.read' },
+        write: { name: 'livechat-visitor.write' },
+    },
+    'livechat-message': {
+        read: { name: 'livechat-message.read' },
+        write: { name: 'livechat-message.write' },
+    },
+    'livechat-room': {
+        read: { name: 'livechat-room.read' },
+        write: { name: 'livechat-room.write' },
+    },
+    'livechat-department': {
+        read: { name: 'livechat-department.read' },
+        write: { name: 'livechat-department.write' },
+    },
+    'env': {
         read: { name: 'env.read' },
     },
-    command: {
-        read: { name: 'command.read' },
-        write: { name: 'command.write' },
+    // Internal permissions
+    'scheduler': {
+        default: { name: 'scheduler' },
     },
-    apis: {
-        general: { name: 'apis.general' },
+    'networking': {
+        default: { name: 'networking', domains: [] } as INetworkingPermission,
+    },
+    'persistence': {
+        default: { name: 'persistence' },
+    },
+    'command': {
+        default: { name: 'slashcommand' },
+    },
+    'apis': {
+        default: { name: 'api' },
     },
 };
 
@@ -75,19 +91,24 @@ export const defaultPermissions: Array<IPermission> = [
     AppPermissions.ui.interaction,
     AppPermissions.setting.read,
     AppPermissions.setting.write,
-    AppPermissions.scheduler.general,
     AppPermissions.room.read,
     AppPermissions.room.write,
-    AppPermissions.persistence.read,
-    AppPermissions.persistence.write,
     AppPermissions.message.read,
     AppPermissions.message.write,
-    AppPermissions.message.notification,
-    AppPermissions.livechat.read,
-    AppPermissions.livechat.write,
-    AppPermissions.networking.general,
+    AppPermissions['livechat-department'].read,
+    AppPermissions['livechat-department'].write,
+    AppPermissions['livechat-room'].read,
+    AppPermissions['livechat-room'].write,
+    AppPermissions['livechat-message'].read,
+    AppPermissions['livechat-message'].write,
+    AppPermissions['livechat-visitor'].read,
+    AppPermissions['livechat-visitor'].write,
+    AppPermissions['livechat-status'].read,
+    AppPermissions['livechat-custom-fields'].write,
+    AppPermissions.scheduler.default,
+    AppPermissions.networking.default,
+    AppPermissions.persistence.default,
     AppPermissions.env.read,
-    AppPermissions.command.read,
-    AppPermissions.command.write,
-    AppPermissions.apis.general,
+    AppPermissions.command.default,
+    AppPermissions.apis.default,
 ];

--- a/src/server/permissions/checkers/AppApisBridge.ts
+++ b/src/server/permissions/checkers/AppApisBridge.ts
@@ -5,10 +5,10 @@ import { AppPermissions } from '../AppPermissions';
 
 export const AppApisBridge = {
     hasGeneralPermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.apis.general)) {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions.apis.default)) {
             throw new PermissionDeniedError({
                 appId,
-                missingPermissions: [AppPermissions.apis.general],
+                missingPermissions: [AppPermissions.apis.default],
             });
         }
     },

--- a/src/server/permissions/checkers/AppCommandsBridge.ts
+++ b/src/server/permissions/checkers/AppCommandsBridge.ts
@@ -4,41 +4,33 @@ import { AppPermissionManager } from '../../managers/AppPermissionManager';
 import { AppPermissions } from '../AppPermissions';
 
 export const AppCommandsBridge = {
-    hasReadPermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.command.read)) {
+    hasPermission(appId: string) {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions.command.default)) {
             throw new PermissionDeniedError({
                 appId,
-                missingPermissions: [AppPermissions.command.read],
-            });
-        }
-    },
-    hasWritePermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.command.write)) {
-            throw new PermissionDeniedError({
-                appId,
-                missingPermissions: [AppPermissions.command.write],
+                missingPermissions: [AppPermissions.command.default],
             });
         }
     },
     doesCommandExist(command: string, appId: string): void {
-        return this.hasReadPermission(appId);
+        return this.hasPermission(appId);
     },
     enableCommand(command: string, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     disableCommand(command: string, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     modifyCommand(command: ISlashCommand, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     restoreCommand(command: string, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     registerCommand(command: ISlashCommand, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     unregisterCommand(command: string, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
 };

--- a/src/server/permissions/checkers/AppHttpBridge.ts
+++ b/src/server/permissions/checkers/AppHttpBridge.ts
@@ -5,10 +5,10 @@ import { AppPermissions } from '../AppPermissions';
 
 export const AppHttpBridge = {
     call(info: IHttpBridgeRequestInfo): void {
-        if (!AppPermissionManager.hasPermission(info.appId, AppPermissions.networking.general)) {
+        if (!AppPermissionManager.hasPermission(info.appId, AppPermissions.networking.default)) {
             throw new PermissionDeniedError({
                 appId: info.appId,
-                missingPermissions: [AppPermissions.networking.general],
+                missingPermissions: [AppPermissions.networking.default],
             });
         }
     },

--- a/src/server/permissions/checkers/AppLivechatBridge.ts
+++ b/src/server/permissions/checkers/AppLivechatBridge.ts
@@ -5,59 +5,134 @@ import { AppPermissionManager } from '../../managers/AppPermissionManager';
 import { AppPermissions } from '../AppPermissions';
 
 export const AppLivechatBridge = {
-    hasReadPermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.livechat.read)) {
-            throw new PermissionDeniedError({
-                appId,
-                missingPermissions: [AppPermissions.livechat.read],
-            });
-        }
-    },
-    hasWritePermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.livechat.write)) {
-            throw new PermissionDeniedError({
-                appId,
-                missingPermissions: [AppPermissions.livechat.write],
-            });
-        }
-    },
     updateMessage(message: ILivechatMessage, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-message'].write)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-message'].write],
+            });
+        }
+
         return this.hasWritePermission(appId);
     },
     createVisitor(visitor: IVisitor, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].write)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-visitor'].write],
+            });
+        }
+
         return this.hasWritePermission(appId);
     },
     findVisitors(query: object, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-visitor'].read],
+            });
+        }
+
         return this.hasReadPermission(appId);
     },
     findVisitorById(id: string, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-visitor'].read],
+            });
+        }
+
         return this.hasReadPermission(appId);
     },
     findVisitorByEmail(email: string, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-visitor'].read],
+            });
+        }
+
         return this.hasReadPermission(appId);
     },
     findVisitorByToken(token: string, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-visitor'].read],
+            });
+        }
+
         return this.hasReadPermission(appId);
     },
-    findVisitorByPhoneNumber(phoneNumber: string, appdId: string): void {
-        return this.hasReadPermission(appdId);
+    findVisitorByPhoneNumber(phoneNumber: string, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-visitor'].read],
+            });
+        }
+
+        return this.hasReadPermission(appId);
     },
     transferVisitor(visitor: IVisitor, transferData: ILivechatTransferData, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].write)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-visitor'].write],
+            });
+        }
+
         return this.hasWritePermission(appId);
     },
     createRoom(visitor: IVisitor, agent: IUser, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-room'].write)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-room'].write],
+            });
+        }
+
         return this.hasWritePermission(appId);
     },
     closeRoom(room: ILivechatRoom, comment: string, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-room'].write)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-room'].write],
+            });
+        }
+
         return this.hasWritePermission(appId);
     },
     findRooms(visitor: IVisitor, departmentId: string | null, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-room'].read)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-room'].read],
+            });
+        }
+
         return this.hasReadPermission(appId);
     },
-    findDepartmentByIdOrName(value: string, appdId: string): void {
-        return this.hasReadPermission(appdId);
+    findDepartmentByIdOrName(value: string, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-department'].read)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-department'].read],
+            });
+        }
+
+        return this.hasReadPermission(appId);
     },
     setCustomFields(data: { token: IVisitor['token']; key: string; value: string; overwrite: boolean }, appId: string): void {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-custom-fields'].write)) {
+            throw new PermissionDeniedError({
+                appId,
+                missingPermissions: [AppPermissions['livechat-custom-fields'].write],
+            });
+        }
+
         return this.hasWritePermission(appId);
     },
 };

--- a/src/server/permissions/checkers/AppLivechatBridge.ts
+++ b/src/server/permissions/checkers/AppLivechatBridge.ts
@@ -12,8 +12,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-message'].write],
             });
         }
-
-        return this.hasWritePermission(appId);
     },
     createVisitor(visitor: IVisitor, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].write)) {
@@ -22,8 +20,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-visitor'].write],
             });
         }
-
-        return this.hasWritePermission(appId);
     },
     findVisitors(query: object, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
@@ -32,8 +28,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-visitor'].read],
             });
         }
-
-        return this.hasReadPermission(appId);
     },
     findVisitorById(id: string, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
@@ -42,8 +36,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-visitor'].read],
             });
         }
-
-        return this.hasReadPermission(appId);
     },
     findVisitorByEmail(email: string, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
@@ -52,8 +44,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-visitor'].read],
             });
         }
-
-        return this.hasReadPermission(appId);
     },
     findVisitorByToken(token: string, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
@@ -62,8 +52,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-visitor'].read],
             });
         }
-
-        return this.hasReadPermission(appId);
     },
     findVisitorByPhoneNumber(phoneNumber: string, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].read)) {
@@ -72,8 +60,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-visitor'].read],
             });
         }
-
-        return this.hasReadPermission(appId);
     },
     transferVisitor(visitor: IVisitor, transferData: ILivechatTransferData, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-visitor'].write)) {
@@ -82,8 +68,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-visitor'].write],
             });
         }
-
-        return this.hasWritePermission(appId);
     },
     createRoom(visitor: IVisitor, agent: IUser, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-room'].write)) {
@@ -92,8 +76,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-room'].write],
             });
         }
-
-        return this.hasWritePermission(appId);
     },
     closeRoom(room: ILivechatRoom, comment: string, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-room'].write)) {
@@ -102,8 +84,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-room'].write],
             });
         }
-
-        return this.hasWritePermission(appId);
     },
     findRooms(visitor: IVisitor, departmentId: string | null, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-room'].read)) {
@@ -112,8 +92,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-room'].read],
             });
         }
-
-        return this.hasReadPermission(appId);
     },
     findDepartmentByIdOrName(value: string, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-department'].read)) {
@@ -122,8 +100,6 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-department'].read],
             });
         }
-
-        return this.hasReadPermission(appId);
     },
     setCustomFields(data: { token: IVisitor['token']; key: string; value: string; overwrite: boolean }, appId: string): void {
         if (!AppPermissionManager.hasPermission(appId, AppPermissions['livechat-custom-fields'].write)) {
@@ -132,7 +108,5 @@ export const AppLivechatBridge = {
                 missingPermissions: [AppPermissions['livechat-custom-fields'].write],
             });
         }
-
-        return this.hasWritePermission(appId);
     },
 };

--- a/src/server/permissions/checkers/AppMessageBridge.ts
+++ b/src/server/permissions/checkers/AppMessageBridge.ts
@@ -23,14 +23,6 @@ export const AppMessageBridge = {
             });
         }
     },
-    hasNotificationPermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.message.notification)) {
-            throw new PermissionDeniedError({
-                appId,
-                missingPermissions: [AppPermissions.message.notification],
-            });
-        }
-    },
     getById(messageId: string, appId: string): void {
         return this.hasReadPermission(appId);
     },
@@ -41,12 +33,12 @@ export const AppMessageBridge = {
         return this.hasWritePermission(appId);
     },
     notifyUser(user: IUser, message: IMessage, appId: string): void {
-        return this.hasNotificationPermission(appId);
+        return this.hasWritePermission(appId);
     },
     notifyRoom(room: IRoom, message: IMessage, appId: string): void {
-        return this.hasNotificationPermission(appId);
+        return this.hasWritePermission(appId);
     },
     typing(options: ITypingDescriptor, appId: string): void {
-        return this.hasNotificationPermission(appId);
+        return this.hasWritePermission(appId);
     },
 };

--- a/src/server/permissions/checkers/AppPersistenceBridge.ts
+++ b/src/server/permissions/checkers/AppPersistenceBridge.ts
@@ -4,19 +4,11 @@ import { AppPermissionManager } from '../../managers/AppPermissionManager';
 import { AppPermissions } from '../AppPermissions';
 
 export const AppPersistenceBridge = {
-    hasReadPermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.persistence.read)) {
+    hasPermission(appId: string) {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions.persistence.default)) {
             throw new PermissionDeniedError({
                 appId,
-                missingPermissions: [AppPermissions.persistence.read],
-            });
-        }
-    },
-    hasWritePermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.persistence.write)) {
-            throw new PermissionDeniedError({
-                appId,
-                missingPermissions: [AppPermissions.persistence.write],
+                missingPermissions: [AppPermissions.persistence.default],
             });
         }
     },

--- a/src/server/permissions/checkers/AppPersistenceBridge.ts
+++ b/src/server/permissions/checkers/AppPersistenceBridge.ts
@@ -13,30 +13,30 @@ export const AppPersistenceBridge = {
         }
     },
     purge(appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     create(data: object, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     createWithAssociations(data: object, associations: Array<RocketChatAssociationRecord>, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     readById(id: string, appId: string): void {
-        return this.hasReadPermission(appId);
+        return this.hasPermission(appId);
     },
     readByAssociations(associations: Array<RocketChatAssociationRecord>, appId: string): void {
-        return this.hasReadPermission(appId);
+        return this.hasPermission(appId);
     },
     remove(id: string, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     removeByAssociation(associations: Array<RocketChatAssociationRecord>, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     update(id: string, data: object, upsert: boolean, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
     updateByAssociation(associations: Array<RocketChatAssociationRecord>, data: object, upsert: boolean, appId: string): void {
-        return this.hasWritePermission(appId);
+        return this.hasPermission(appId);
     },
 };

--- a/src/server/permissions/checkers/AppSchedulerBridge.ts
+++ b/src/server/permissions/checkers/AppSchedulerBridge.ts
@@ -5,10 +5,10 @@ import { AppPermissions } from '../AppPermissions';
 
 export const AppSchedulerBridge = {
     hasGeneralPermission(appId: string) {
-        if (!AppPermissionManager.hasPermission(appId, AppPermissions.scheduler.general)) {
+        if (!AppPermissionManager.hasPermission(appId, AppPermissions.scheduler.default)) {
             throw new PermissionDeniedError({
                 appId,
-                missingPermissions: [AppPermissions.scheduler.general],
+                missingPermissions: [AppPermissions.scheduler.default],
             });
         }
     },


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
After a review with some other team members, these are the suggestions that came up:

## The "general" scope and internal permissions
Having the `.general` suffix for the permissions was not a good name. The suggestion was to change it to `.manage`, but in the end, removing the suffixes altogether seemed like a better option. This way, we can have developers declare the permissions in the manifest file as `{ name: "scheduler" }`, for instance, and we maintain our internal structure by defining a "default" scope for those permissions.

We could also observe the permissions could be split into two categories: _internal_ and _system_ permissions. _Internal_ permissions were the ones that shared the `.general` suffix - they represent a feature that the app uses to manage it's own functionality internally and how it interfaces with the outside world, e.g. `scheduler`, `slashcommand`, `persistence`. These permissions do not need to be split into "read" and "write" scopes because they control "isolated" components, in a context that belongs only to the app in question. For instance, the `slashcommand` permission does not allow an app to read or write slash commands registered by other apps, only its own slash commands; also, having a `slashcommand.write` permission without having a `slashcommand.read` permission wouldn't make sense for the app, as it does not _actually_ reads and writes information residing elsewhere, but rather only register a new command and handle its execution. These internal permissions now have a single default scope, without the need for suffixing it when declaring them.

_System_ permissions are the ones that control access to resources _external_ to the app, data that does not _belong_ to it. Things like `messages`, `rooms`, server-settings, etc.

## The livechat permissions
Even though we have only one bridge for all things livechat, it manages access to more than one type of resource. Namely, we have messages, visitors, departments, etc. We split up the single "livechat" permission into multiple ones, regarding each type of resource available.

## The message.notification permission
Although internally being handled in a very different way from persistent messages, notifications are still messages in essence. Because of that, we removed the `message.notification` and require the same `message.write` permission for sending notifications (a.k.a ephemeral messages)

## The ui.interaction permission
Other _system_ permissions have "read" and "write" scopes, verbs describing the type of action the scope allows. So the `ui.interaction` permission has been changed to `ui.interact`.
