### PR TITLE
Rergession: Change file content from stream to Buffer

### DIFF
--- a/src/definition/uploads/IFileUploadContext.ts
+++ b/src/definition/uploads/IFileUploadContext.ts
@@ -1,8 +1,7 @@
-import { Stream } from 'stream';
 
 import { IUploadDetails } from './IUploadDetails';
 
 export interface IFileUploadContext {
     file: IUploadDetails;
-    stream: Stream;
+    content: Buffer;
 }

--- a/src/server/permissions/checkers/AppSchedulerBridge.ts
+++ b/src/server/permissions/checkers/AppSchedulerBridge.ts
@@ -24,7 +24,5 @@ export const AppSchedulerBridge = {
     cancelJob(jobId: string, appId: string): void {
         return this.hasGeneralPermission(appId);
     },
-    cancelAllJobs(appId: string): void {
-        return this.hasGeneralPermission(appId);
-    },
+    cancelAllJobs(appId: string): void { },
 };


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
See title

# Why? :thinking:
<!--Additional explanation if needed-->
Providing a stream so apps can access the file content would break the functionality, as once the stream has finished emitting data, it's not possible to rewind it. This would mean that whenever an app reads the contents of the stream, any subsequent app, and even Rocket.Chat, would not be able to do so.

Changing it to a Buffer allows all parties to read the contents of the file.
