### PR TITLE
Add showIcon to view payload in modal interactions from UIKit

### DIFF
--- a/src/definition/uikit/UIKitInteractionPayloadFormatter.ts
+++ b/src/definition/uikit/UIKitInteractionPayloadFormatter.ts
@@ -1,6 +1,6 @@
 import { IUIKitErrorInteractionParam } from '../accessors/IUIController';
 import { IUIKitErrorInteraction, IUIKitInteraction, IUIKitModalInteraction, UIKitInteractionType } from './IUIKitInteractionType';
-import { UIKitViewType } from './IUIKitView';
+import { IUIKitView, UIKitViewType } from './IUIKitView';
 import { IUIKitModalViewParam } from './UIKitInteractionResponder';
 
 import uuid = require('uuid/v1');
@@ -21,7 +21,8 @@ export function formatModalInteraction(view: IUIKitModalViewParam, context: IUIK
             type: UIKitViewType.MODAL,
             id: view.id ? view.id : uuid(),
             ...view,
-        },
+            showIcon: true,
+        } as IUIKitView,
     };
 }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
See title

# Why? :thinking:
<!--Additional explanation if needed-->
Rocket.Chat is introducing the support to the `showIcon` property in the view payload sent to show/update in order to support the concept of "core apps" (more info on this later), which won't have icons available to show. However, this property is not intended to be used directly by third-party apps, so it has been added as a constant value.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
