### PR TITLE
[Fix] Jobs running when the app is disabled

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -245,6 +245,7 @@ export class AppManager {
                 await this.enableApp(items.get(app.getID()), app, true, app.getPreviousStatus() === AppStatus.MANUALLY_ENABLED).catch(console.error);
             } else if (!AppStatusUtils.isError(app.getStatus())) {
                 this.listenerManager.lockEssentialEvents(app);
+                await this.schedulerManager.cancelAllJobs(app.getID());
             }
         }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Cancel all jobs registered by the app as soon as it gets loaded (server startup) when the app status is marked as "disabled"

# Why? :thinking:
<!--Additional explanation if needed-->
During the startup process, all apps have their "configurationExtend" method run, regardless of whether they are enabled. In this method, we also define the processors (job functions) that will be run by the app, including the ones that should be run as soon as they get registered, without manual triggering. This tasks that run automatically were run because of the app being loaded, not taking in consideration the app's state.


# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
