### PR TITLE
Chore: Add description value to IRoom interface

### DIFF
--- a/src/definition/rooms/IRoom.ts
+++ b/src/definition/rooms/IRoom.ts
@@ -19,6 +19,7 @@ export interface IRoom {
     createdAt?: Date;
     updatedAt?: Date;
     lastModifiedAt?: Date;
+    description?: string;
     customFields?: { [key: string]: any };
     parentRoom?: IRoom;
     livechatData?: { [key: string]: any };


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
**Added** the `description` value to a `IRoom` interface. The `description` value refers to a room topic.

# Why? :thinking:
<!--Additional explanation if needed-->
To allow developers to get the `description` information from a room.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
Fixes https://github.com/RocketChat/Rocket.Chat.Apps-engine/issues/203

# PS :eyes:
