### PR TITLE
[NEW] Add possibility to set room closer to LivechatUpdater.closeRoom

### DIFF
--- a/src/definition/accessors/ILivechatUpdater.ts
+++ b/src/definition/accessors/ILivechatUpdater.ts
@@ -1,5 +1,6 @@
 import { ILivechatTransferData, IVisitor } from '../livechat';
 import { IRoom } from '../rooms';
+import { IUser } from '../users';
 
 export interface ILivechatUpdater {
     /**
@@ -15,8 +16,9 @@ export interface ILivechatUpdater {
      *
      * @param room The room to be closed
      * @param comment The comment explaining the reason for closing the room
+     * @param closer The user that closes the room
      */
-    closeRoom(room: IRoom, comment: string): Promise<boolean>;
+    closeRoom(room: IRoom, comment: string, closer?: IUser): Promise<boolean>;
 
     /**
      * Set a livechat visitor's custom fields by its token

--- a/src/server/accessors/LivechatUpdater.ts
+++ b/src/server/accessors/LivechatUpdater.ts
@@ -1,5 +1,6 @@
 import { ILivechatUpdater } from '../../definition/accessors';
 import { ILivechatRoom, ILivechatTransferData, IVisitor } from '../../definition/livechat';
+import { IUser } from '../../definition/users';
 import { AppBridges } from '../bridges';
 
 export class LivechatUpdater implements ILivechatUpdater {
@@ -9,8 +10,8 @@ export class LivechatUpdater implements ILivechatUpdater {
         return this.bridges.getLivechatBridge().doTransferVisitor(visitor, transferData, this.appId);
     }
 
-    public closeRoom(room: ILivechatRoom, comment: string): Promise<boolean> {
-        return this.bridges.getLivechatBridge().doCloseRoom(room, comment, this.appId);
+    public closeRoom(room: ILivechatRoom, comment: string, closer?: IUser): Promise<boolean> {
+        return this.bridges.getLivechatBridge().doCloseRoom(room, comment, closer, this.appId);
     }
 
     public setCustomFields(token: IVisitor['token'], key: string, value: string, overwrite: boolean): Promise<boolean> {

--- a/src/server/bridges/LivechatBridge.ts
+++ b/src/server/bridges/LivechatBridge.ts
@@ -116,9 +116,9 @@ export abstract class LivechatBridge extends BaseBridge {
        }
     }
 
-   public async doCloseRoom(room: ILivechatRoom, comment: string, appId: string): Promise<boolean> {
+   public async doCloseRoom(room: ILivechatRoom, comment: string, closer: IUser | undefined, appId: string): Promise<boolean> {
        if (this.hasWritePermission(appId, 'livechat-room')) {
-           return this.closeRoom(room, comment, appId);
+           return this.closeRoom(room, comment, closer, appId);
        }
     }
 
@@ -174,7 +174,7 @@ export abstract class LivechatBridge extends BaseBridge {
     protected abstract findVisitorByPhoneNumber(phoneNumber: string, appId: string): Promise<IVisitor | undefined>;
     protected abstract transferVisitor(visitor: IVisitor, transferData: ILivechatTransferData, appId: string): Promise<boolean>;
     protected abstract createRoom(visitor: IVisitor, agent: IUser, appId: string): Promise<ILivechatRoom>;
-    protected abstract closeRoom(room: ILivechatRoom, comment: string, appId: string): Promise<boolean>;
+    protected abstract closeRoom(room: ILivechatRoom, comment: string, closer: IUser | undefined, appId: string): Promise<boolean>;
     protected abstract findRooms(visitor: IVisitor, departmentId: string | null, appId: string): Promise<Array<ILivechatRoom>>;
     protected abstract findDepartmentByIdOrName(value: string, appId: string): Promise<IDepartment | undefined>;
     protected abstract findDepartmentsEnabledWithAgents(appId: string): Promise<Array<IDepartment>>;

--- a/tests/test-data/bridges/livechatBridge.ts
+++ b/tests/test-data/bridges/livechatBridge.ts
@@ -47,7 +47,7 @@ export class TestLivechatBridge extends LivechatBridge {
     public createRoom(visitor: IVisitor, agent: IUser, appId: string): Promise<ILivechatRoom> {
         throw new Error('Method not implemented');
     }
-    public closeRoom(room: ILivechatRoom, comment: string, appId: string): Promise<boolean> {
+    public closeRoom(room: ILivechatRoom, comment: string, closer: IUser | undefined, appId: string): Promise<boolean> {
         throw new Error('Method not implemented');
     }
     public findRooms(visitor: IVisitor, departmentId: string | null, appId: string): Promise<Array<ILivechatRoom>> {


### PR DESCRIPTION
# What? :boat:
* Add an optional param named `closer` into `LivechatUpdater.closeRoom` so that we can close the room with the correct closer.
closes #373
# Why? :thinking:
When closing the room with the Apps, the room closer and the close room message sender will always be set to the visitor. This is not a correct behavior because the visitor does not perform that function.
This is not a very clean approach, we actually should pass something like `closeData` which contains all the needed data for Rocket.Chat close room function, but to avoid breaking change we can accept this approach right now

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
Rocket.Chat issue: RocketChat/Rocket.Chat#21025

# PS :eyes:
