### PR TITLE
Add `skipImmediate` property to the IRecurringSchedule interface

### DIFF
--- a/src/definition/scheduler/IProcessor.ts
+++ b/src/definition/scheduler/IProcessor.ts
@@ -32,6 +32,7 @@ export interface IOnetimeStartup {
 export interface IRecurringStartup {
     type: StartupType.RECURRING;
     interval: string | number;
+    skipImmediate?: boolean;
     data?: object;
 }
 

--- a/src/definition/scheduler/IRecurringSchedule.ts
+++ b/src/definition/scheduler/IRecurringSchedule.ts
@@ -8,6 +8,10 @@ export interface IRecurringSchedule {
      * or a number.
      */
     interval: string | number;
+    /**
+     * Whether to let the first iteration to execute as soon as the task is registered
+     */
+    skipImmediate?: boolean;
     /** An object that can be passed to the processor with custom data */
     data?: object;
 }

--- a/src/definition/scheduler/IRecurringSchedule.ts
+++ b/src/definition/scheduler/IRecurringSchedule.ts
@@ -9,7 +9,7 @@ export interface IRecurringSchedule {
      */
     interval: string | number;
     /**
-     * Whether to let the first iteration to execute as soon as the task is registered
+     * Whether the recurring job should start immediately or wait for the interval
      */
     skipImmediate?: boolean;
     /** An object that can be passed to the processor with custom data */


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Adds a property lets the developer decide whether they want the first iteration of a recurring task to be executed immediately instead of waiting for the defined interval to complete

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
