### PR TITLE
[FIX] Apps-Engine UI comms incorrectly validated data in listener

### DIFF
--- a/src/client/AppsEngineUIClient.ts
+++ b/src/client/AppsEngineUIClient.ts
@@ -36,7 +36,7 @@ export class AppsEngineUIClient {
      */
     public init(): void {
         this.listener = ({ data }) => {
-            if (!data.hasOwnProperty(MESSAGE_ID)) {
+            if (!data?.hasOwnProperty(MESSAGE_ID)) {
                 return;
             }
 

--- a/src/client/AppsEngineUIHost.ts
+++ b/src/client/AppsEngineUIHost.ts
@@ -25,7 +25,7 @@ export abstract class AppsEngineUIHost {
      */
     public initialize() {
         window.addEventListener('message', async ({ data, source }) => {
-            if (!data.hasOwnProperty(MESSAGE_ID)) {
+            if (!data?.hasOwnProperty(MESSAGE_ID)) {
                 return;
             }
 
@@ -36,8 +36,10 @@ export abstract class AppsEngineUIHost {
             switch (action) {
                 case AppsEngineUIMethods.GET_USER_INFO:
                     this.handleAction(action, id, await this.getClientUserInfo());
+                    break;
                 case AppsEngineUIMethods.GET_ROOM_INFO:
                     this.handleAction(action, id, await this.getClientRoomInfo());
+                    break;
             }
         });
     }

--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.25.0-alpha",
+  "version": "1.26.0-beta",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Fixes a bug that causes the listener to error out when it receives an event with no data
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
