### PR TITLE
[FIX] Update getValueById for properly getting value for BOOLEAN and STRING Setting

### DIFF
--- a/src/server/accessors/ServerSettingRead.ts
+++ b/src/server/accessors/ServerSettingRead.ts
@@ -17,7 +17,11 @@ export class ServerSettingRead implements IServerSettingRead {
             throw new Error(`No Server Setting found, or it is unaccessible, by the id of "${id}".`);
         }
 
-        return set.value || set.packageValue;
+        if (set.value === undefined || set.value === null) {
+            return set.packageValue;
+        }
+
+        return set.value;
     }
 
     public getAll(): Promise<IterableIterator<ISetting>> {

--- a/src/server/accessors/SettingRead.ts
+++ b/src/server/accessors/SettingRead.ts
@@ -17,6 +17,10 @@ export class SettingRead implements ISettingRead {
             throw new Error(`Setting "${id}" does not exist.`);
         }
 
-        return set.value || set.packageValue;
+        if (set.value === undefined || set.value === null) {
+            return set.packageValue;
+        }
+
+        return set.value;
     }
 }


### PR DESCRIPTION
# Fixes https://github.com/RocketChat/Rocket.Chat.Apps-engine/issues/425

# What? :boat:

- Updated ISettingRead getValueById
- Updated IServerSettingRead getValueById

# Why?

#### Earlier Behaviour
```
public async getValueById(id: string): Promise<any> {
        const set = await this.settingBridge.getOneById(id, this.appId);

        if (typeof set === 'undefined') {
            throw new Error(`No Server Setting found, or it is unaccessible, by the id of "${id}".`);
        }

        return set.value || set.packageValue;
    }
```

The issue is with the BOOLEAN settings. When `packageValue` (default value) is set to true and `value` (current value) if false,
It returns true because of `OR ||`.

Similar issue when setting value is `''` for STRING Setting.

#### Behaviour after this PR

Properly returns BOOLEAN and STRING setting