### PR TITLE
Fix wrong permission on department read method

### DIFF
--- a/src/server/bridges/LivechatBridge.ts
+++ b/src/server/bridges/LivechatBridge.ts
@@ -122,7 +122,7 @@ export abstract class LivechatBridge extends BaseBridge {
     }
 
    public async doFindDepartmentByIdOrName(value: string, appId: string): Promise<IDepartment | undefined> {
-       if (this.hasReadPermission(appId, 'livechat-department') && this.hasMultiplePermission(appId)) {
+       if (this.hasReadPermission(appId, 'livechat-department') || this.hasMultiplePermission(appId)) {
            return this.findDepartmentByIdOrName(value, appId);
        }
     }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Fix wrong permission check in the `doFindDepartmentByIdOrName` method

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
