### PR TITLE
[FIX] Make username property optional for IVisitor

### DIFF
--- a/docs/interfaces/livechat_ivisitor.ivisitor.html
+++ b/docs/interfaces/livechat_ivisitor.ivisitor.html
@@ -198,7 +198,7 @@
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface">
 					<a name="username" class="tsd-anchor"></a>
-					<h3>username</h3>
+					<h3><span class="tsd-flag ts-flagOptional">Optional</span> username</h3>
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>

--- a/src/definition/livechat/IVisitor.ts
+++ b/src/definition/livechat/IVisitor.ts
@@ -4,7 +4,7 @@ import { IVisitorPhone } from './IVisitorPhone';
 export interface IVisitor {
     id?: string;
     token: string;
-    username: string;
+    username?: string;
     updatedAt?: Date;
     name: string;
     department?: string;


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
The `IVisitor` interface of the apps engine currently makes the usernames field mandatory, however this isn't required as on the backend we have a logic in-place to generate a new username if no usernames are provided
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
