### PR TITLE
[IMPROVE] Return task ids when using the scheduler api

### DIFF
--- a/src/definition/accessors/ISchedulerExtend.ts
+++ b/src/definition/accessors/ISchedulerExtend.ts
@@ -5,6 +5,7 @@ export interface ISchedulerExtend {
      * Register processors that can be scheduled to run
      *
      * @param {Array<IProcessor>} processors An array of processors
+     * @returns List of task ids run at startup, or void no startup run is set
      */
-    registerProcessors(processors: Array<IProcessor>): Promise<void>;
+    registerProcessors(processors: Array<IProcessor>): Promise<void | Array<string>>;
 }

--- a/src/definition/accessors/ISchedulerModify.ts
+++ b/src/definition/accessors/ISchedulerModify.ts
@@ -11,14 +11,16 @@ export interface ISchedulerModify {
      * Schedules a registered processor to run _once_.
      *
      * @param {IOnetimeSchedule} job
+     * @returns jobid as string
      */
-    scheduleOnce(job: IOnetimeSchedule): Promise<void>;
+    scheduleOnce(job: IOnetimeSchedule): Promise<void | string>;
     /**
      * Schedules a registered processor to run in recurrencly according to a given interval
      *
      * @param {IRecurringSchedule} job
+     * @returns jobid as string
      */
-    scheduleRecurring(job: IRecurringSchedule): Promise<void>;
+    scheduleRecurring(job: IRecurringSchedule): Promise<void | string>;
     /**
      * Cancels a running job given its jobId
      *

--- a/src/server/accessors/SchedulerExtend.ts
+++ b/src/server/accessors/SchedulerExtend.ts
@@ -5,7 +5,7 @@ import { AppSchedulerManager } from '../managers/AppSchedulerManager';
 export class SchedulerExtend implements ISchedulerExtend {
     constructor(private readonly manager: AppSchedulerManager, private readonly appId: string) {}
 
-    public async registerProcessors(processors: Array<IProcessor> = []): Promise<void> {
-        await this.manager.registerProcessors(processors, this.appId);
+    public async registerProcessors(processors: Array<IProcessor> = []): Promise<void | Array<string>> {
+        return this.manager.registerProcessors(processors, this.appId);
     }
 }

--- a/src/server/accessors/SchedulerModify.ts
+++ b/src/server/accessors/SchedulerModify.ts
@@ -12,12 +12,12 @@ function createProcessorId(jobId: string, appId: string): string {
 export class SchedulerModify implements ISchedulerModify {
     constructor(private readonly bridge: SchedulerBridge, private readonly appId: string) {}
 
-    public async scheduleOnce(job: IOnetimeSchedule): Promise<void> {
-        this.bridge.doScheduleOnce({ ...job, id: createProcessorId(job.id, this.appId) }, this.appId);
+    public async scheduleOnce(job: IOnetimeSchedule): Promise<void | string> {
+        return this.bridge.doScheduleOnce({ ...job, id: createProcessorId(job.id, this.appId) }, this.appId);
     }
 
-    public async scheduleRecurring(job: IRecurringSchedule): Promise<void> {
-        this.bridge.doScheduleRecurring({ ...job, id: createProcessorId(job.id, this.appId) }, this.appId);
+    public async scheduleRecurring(job: IRecurringSchedule): Promise<void | string> {
+        return this.bridge.doScheduleRecurring({ ...job, id: createProcessorId(job.id, this.appId) }, this.appId);
     }
 
     public async cancelJob(jobId: string): Promise<void> {

--- a/src/server/bridges/SchedulerBridge.ts
+++ b/src/server/bridges/SchedulerBridge.ts
@@ -9,19 +9,19 @@ import { AppPermissions } from '../permissions/AppPermissions';
 import { BaseBridge } from './BaseBridge';
 
 export abstract class SchedulerBridge extends BaseBridge {
-    public async doRegisterProcessors(processors: Array<IProcessor> = [], appId: string): Promise<void> {
+    public async doRegisterProcessors(processors: Array<IProcessor> = [], appId: string): Promise<void | Array<string>> {
         if (this.hasDefaultPermission(appId)) {
             return this.registerProcessors(processors, appId);
         }
     }
 
-    public async doScheduleOnce(job: IOnetimeSchedule, appId: string): Promise<void> {
+    public async doScheduleOnce(job: IOnetimeSchedule, appId: string): Promise<void | string> {
         if (this.hasDefaultPermission(appId)) {
             return this.scheduleOnce(job, appId);
         }
     }
 
-    public async doScheduleRecurring(job: IRecurringSchedule, appId: string): Promise<void> {
+    public async doScheduleRecurring(job: IRecurringSchedule, appId: string): Promise<void | string> {
         if (this.hasDefaultPermission(appId)) {
             return this.scheduleRecurring(job, appId);
         }
@@ -39,9 +39,9 @@ export abstract class SchedulerBridge extends BaseBridge {
         }
     }
 
-    protected abstract registerProcessors(processors: Array<IProcessor>, appId: string): Promise<void>;
-    protected abstract scheduleOnce(job: IOnetimeSchedule, appId: string): Promise<void>;
-    protected abstract scheduleRecurring(job: IRecurringSchedule, appId: string): Promise<void>;
+    protected abstract registerProcessors(processors: Array<IProcessor>, appId: string): Promise<void | Array<string>>;
+    protected abstract scheduleOnce(job: IOnetimeSchedule, appId: string): Promise<void | string>;
+    protected abstract scheduleRecurring(job: IRecurringSchedule, appId: string): Promise<void | string>;
     protected abstract cancelJob(jobId: string, appId: string): Promise<void>;
     protected abstract cancelAllJobs(appId: string): Promise<void>;
 

--- a/src/server/managers/AppSchedulerManager.ts
+++ b/src/server/managers/AppSchedulerManager.ts
@@ -26,12 +26,12 @@ export class AppSchedulerManager {
         this.registeredProcessors = new Map();
     }
 
-    public async registerProcessors(processors: Array<IProcessor> = [], appId: string): Promise<void> {
+    public async registerProcessors(processors: Array<IProcessor> = [], appId: string): Promise<void | Array<string>> {
         if (!this.registeredProcessors.get(appId)) {
             this.registeredProcessors.set(appId, {});
         }
 
-        await this.bridge.doRegisterProcessors(processors.map((processor) => {
+        return this.bridge.doRegisterProcessors(processors.map((processor) => {
             const processorId = createProcessorId(processor.id, appId);
 
             this.registeredProcessors.get(appId)[processorId] = processor;
@@ -83,12 +83,12 @@ export class AppSchedulerManager {
         };
     }
 
-    public async scheduleOnce(job: IOnetimeSchedule, appId: string): Promise<void> {
-        this.bridge.doScheduleOnce({ ...job, id: createProcessorId(job.id, appId) }, appId);
+    public async scheduleOnce(job: IOnetimeSchedule, appId: string): Promise<void | string> {
+        return this.bridge.doScheduleOnce({ ...job, id: createProcessorId(job.id, appId) }, appId);
     }
 
-    public async scheduleRecurring(job: IRecurringSchedule, appId: string): Promise<void> {
-        this.bridge.doScheduleRecurring({ ...job, id: createProcessorId(job.id, appId) }, appId);
+    public async scheduleRecurring(job: IRecurringSchedule, appId: string): Promise<void | string> {
+        return this.bridge.doScheduleRecurring({ ...job, id: createProcessorId(job.id, appId) }, appId);
     }
 
     public async cancelJob(jobId: string, appId: string): Promise<void> {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
In the methods that create tasks (scheduleRecurring and scheduleOnce) return the id of the document created in the database so the user can cancel each task individually.
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
