### PR TITLE
[NEW] Add a bridge to the INet interface

### DIFF
--- a/src/definition/accessors/IAppAccessors.ts
+++ b/src/definition/accessors/IAppAccessors.ts
@@ -1,9 +1,10 @@
-import { IEnvironmentRead, IHttp, IRead } from '../../definition/accessors';
+import { IEnvironmentRead, IHttp, INet, IRead } from '../../definition/accessors';
 import { IApiEndpointMetadata } from '../api';
 
 export interface IAppAccessors {
     readonly environmentReader: IEnvironmentRead;
     readonly reader: IRead;
     readonly http: IHttp;
+    readonly net: INet;
     readonly providedApiEndpoints: Array<IApiEndpointMetadata>;
 }

--- a/src/definition/accessors/INet.ts
+++ b/src/definition/accessors/INet.ts
@@ -1,0 +1,3 @@
+export interface INet {
+    createConnection(options: {}): NodeJS.Socket;
+}

--- a/src/definition/accessors/index.ts
+++ b/src/definition/accessors/index.ts
@@ -24,6 +24,7 @@ import { IModifyCreator } from './IModifyCreator';
 import { IModifyDeleter } from './IModifyDeleter';
 import { IModifyExtender } from './IModifyExtender';
 import { IModifyUpdater } from './IModifyUpdater';
+import { INet } from './INet';
 import { INotifier } from './INotifier';
 import { IPersistence } from './IPersistence';
 import { IPersistenceRead } from './IPersistenceRead';
@@ -77,6 +78,7 @@ export {
     IModifyDeleter,
     IModifyExtender,
     IModifyUpdater,
+    INet,
     INotifier,
     IPersistence,
     IPersistenceRead,

--- a/src/server/accessors/AppAccessors.ts
+++ b/src/server/accessors/AppAccessors.ts
@@ -1,4 +1,4 @@
-import { IAppAccessors, IEnvironmentRead, IHttp, IRead } from '../../definition/accessors';
+import { IAppAccessors, IEnvironmentRead, IHttp, INet, IRead } from '../../definition/accessors';
 import { IApiEndpointMetadata } from '../../definition/api';
 import { AppManager } from '../AppManager';
 import { AppAccessorManager } from '../managers/AppAccessorManager';
@@ -27,5 +27,9 @@ export class AppAccessors implements IAppAccessors {
 
     public get providedApiEndpoints(): Array<IApiEndpointMetadata> {
         return this.apiManager.listApis(this.appId);
+    }
+
+    public get net(): INet {
+        return this.accessorManager.getNet(this.appId);
     }
 }

--- a/src/server/accessors/Net.ts
+++ b/src/server/accessors/Net.ts
@@ -1,0 +1,10 @@
+import { INet } from '../../definition/accessors/INet';
+import { AppBridges } from '../bridges/AppBridges';
+
+export class Net implements INet {
+    constructor(private readonly bridges: AppBridges,
+                private readonly appId: string) { }
+    public createConnection(options: object): NodeJS.Socket {
+        return this.bridges.getNetBridge().doCreateConnection(options, this.appId);
+    }
+}

--- a/src/server/accessors/index.ts
+++ b/src/server/accessors/index.ts
@@ -15,6 +15,7 @@ import { Modify } from './Modify';
 import { ModifyCreator } from './ModifyCreator';
 import { ModifyExtender } from './ModifyExtender';
 import { ModifyUpdater } from './ModifyUpdater';
+import { Net } from './Net';
 import { Notifier } from './Notifier';
 import { Persistence } from './Persistence';
 import { PersistenceRead } from './PersistenceRead';
@@ -52,6 +53,7 @@ export {
     ModifyCreator,
     ModifyExtender,
     ModifyUpdater,
+    Net,
     Notifier,
     Persistence,
     PersistenceRead,

--- a/src/server/bridges/AppBridges.ts
+++ b/src/server/bridges/AppBridges.ts
@@ -9,6 +9,7 @@ import { IInternalBridge } from './IInternalBridge';
 import { IListenerBridge } from './IListenerBridge';
 import { LivechatBridge } from './LivechatBridge';
 import { MessageBridge } from './MessageBridge';
+import { NetBridge } from './NetBridge';
 import { PersistenceBridge } from './PersistenceBridge';
 import { RoomBridge } from './RoomBridge';
 import { SchedulerBridge } from './SchedulerBridge';
@@ -43,6 +44,7 @@ export abstract class AppBridges {
     public abstract getListenerBridge(): IListenerBridge;
     public abstract getLivechatBridge(): LivechatBridge;
     public abstract getMessageBridge(): MessageBridge;
+    public abstract getNetBridge(): NetBridge;
     public abstract getPersistenceBridge(): PersistenceBridge;
     public abstract getAppActivationBridge(): AppActivationBridge;
     public abstract getRoomBridge(): RoomBridge;

--- a/src/server/bridges/NetBridge.ts
+++ b/src/server/bridges/NetBridge.ts
@@ -1,0 +1,28 @@
+import { PermissionDeniedError } from '../errors/PermissionDeniedError';
+import { AppPermissionManager } from '../managers/AppPermissionManager';
+import { AppPermissions } from '../permissions/AppPermissions';
+import { BaseBridge } from './BaseBridge';
+
+export abstract class NetBridge extends BaseBridge {
+
+    public doCreateConnection(options: object, appId: string): NodeJS.Socket {
+      if (this.hasDefaultPermission(appId)) {
+          return this.createConnection(options);
+      }
+    }
+
+    protected abstract createConnection(options: object): NodeJS.Socket;
+
+    private hasDefaultPermission(appId: string): boolean {
+        if (AppPermissionManager.hasPermission(appId, AppPermissions.networking.default)) {
+            return true;
+        }
+
+        AppPermissionManager.notifyAboutError(new PermissionDeniedError({
+            appId,
+            missingPermissions: [AppPermissions.networking.default],
+        }));
+
+        return false;
+    }
+}

--- a/src/server/bridges/index.ts
+++ b/src/server/bridges/index.ts
@@ -10,6 +10,7 @@ import { IInternalBridge } from './IInternalBridge';
 import { IListenerBridge } from './IListenerBridge';
 import { LivechatBridge } from './LivechatBridge';
 import { MessageBridge } from './MessageBridge';
+import { NetBridge } from './NetBridge';
 import { PersistenceBridge } from './PersistenceBridge';
 import { RoomBridge } from './RoomBridge';
 import { SchedulerBridge } from './SchedulerBridge';
@@ -26,6 +27,7 @@ export {
     IListenerBridge,
     LivechatBridge,
     MessageBridge,
+    NetBridge,
     PersistenceBridge,
     AppActivationBridge,
     AppDetailChangesBridge,

--- a/src/server/managers/AppAccessorManager.ts
+++ b/src/server/managers/AppAccessorManager.ts
@@ -5,6 +5,7 @@ import {
     IHttp,
     IHttpExtend,
     IModify,
+    INet,
     IPersistence,
     IRead,
 } from '../../definition/accessors';
@@ -20,6 +21,7 @@ import {
     LivechatRead,
     MessageRead,
     Modify,
+    Net,
     Notifier,
     Persistence,
     PersistenceRead,
@@ -49,6 +51,7 @@ export class AppAccessorManager {
     private readonly modifiers: Map<string, IModify>;
     private readonly persists: Map<string, IPersistence>;
     private readonly https: Map<string, IHttp>;
+    private readonly nets: Map<string, INet>;
 
     constructor(private readonly manager: AppManager) {
         this.bridges = this.manager.getBridges();
@@ -59,6 +62,7 @@ export class AppAccessorManager {
         this.modifiers = new Map<string, IModify>();
         this.persists = new Map<string, IPersistence>();
         this.https = new Map<string, IHttp>();
+        this.nets = new Map<string, INet>();
     }
 
     /**
@@ -74,6 +78,7 @@ export class AppAccessorManager {
         this.modifiers.delete(appId);
         this.persists.delete(appId);
         this.https.delete(appId);
+        this.nets.delete(appId);
     }
 
     public getConfigurationExtend(appId: string): IConfigurationExtend {
@@ -175,5 +180,12 @@ export class AppAccessorManager {
         }
 
         return this.https.get(appId);
+    }
+
+    public getNet(appId: string): INet {
+        if (!this.nets.has(appId)) {
+            this.nets.set(appId, new Net(this.bridges, appId));
+        }
+        return this.nets.get(appId);
     }
 }

--- a/tests/server/accessors/Net.spec.ts
+++ b/tests/server/accessors/Net.spec.ts
@@ -1,0 +1,39 @@
+import { Expect, SetupFixture, SpyOn, Test } from 'alsatian';
+
+import { Net } from '../../../src/server/accessors';
+import { AppBridges, NetBridge } from '../../../src/server/bridges';
+
+export class NetAccessorsTestFixture {
+    private mockAppBridge: AppBridges;
+    private mockAppId: string;
+    private mockNetBridge: NetBridge;
+    private mockSocket: NodeJS.Socket;
+
+    @SetupFixture
+    public setupFixture() {
+        this.mockAppId = 'testing-app';
+
+        const socket = this.mockSocket as NodeJS.Socket;
+        this.mockNetBridge = {
+            doCreateConnection(options: {}, appId: string): NodeJS.Socket {
+                return socket;
+            },
+        } as NetBridge;
+
+        const netBridge = this.mockNetBridge;
+        this.mockAppBridge = {
+            getNetBridge(): NetBridge {
+                return netBridge;
+            },
+        } as AppBridges;
+    }
+
+    @Test()
+    public useNet() {
+        Expect(() => new Net(this.mockAppBridge, this.mockAppId)).not.toThrow();
+
+        const net = new Net(this.mockAppBridge, this.mockAppId);
+        SpyOn(this.mockNetBridge, 'doCreateConnection');
+        SpyOn(net, 'createConnection');
+    }
+}

--- a/tests/test-data/bridges/appBridges.ts
+++ b/tests/test-data/bridges/appBridges.ts
@@ -8,6 +8,7 @@ import {
     IListenerBridge,
     LivechatBridge,
     MessageBridge,
+    NetBridge,
     PersistenceBridge,
     RoomBridge,
     SchedulerBridge,
@@ -27,6 +28,7 @@ import { TestsHttpBridge } from './httpBridge';
 import { TestsInternalBridge } from './internalBridge';
 import { TestLivechatBridge } from './livechatBridge';
 import { TestsMessageBridge } from './messageBridge';
+import { TestsNetBridge } from './netBridge';
 import { TestsPersisBridge } from './persisBridge';
 import { TestsRoomBridge } from './roomBridge';
 import { TestSchedulerBridge } from './schedulerBridge';
@@ -51,6 +53,7 @@ export class TestsAppBridges extends AppBridges {
     private readonly livechatBridge: TestLivechatBridge;
     private readonly uploadBridge: TestUploadBridge;
     private readonly uiIntegrationBridge: TestsUiIntegrationBridge;
+    private readonly netBridge: TestsNetBridge;
     private readonly schedulerBridge: TestSchedulerBridge;
     private readonly cloudWorkspaceBridge: TestAppCloudWorkspaceBridge;
 
@@ -71,6 +74,7 @@ export class TestsAppBridges extends AppBridges {
         this.livechatBridge = new TestLivechatBridge();
         this.uploadBridge = new TestUploadBridge();
         this.uiIntegrationBridge = new TestsUiIntegrationBridge();
+        this.netBridge = new TestsNetBridge();
         this.schedulerBridge = new TestSchedulerBridge();
         this.cloudWorkspaceBridge = new TestAppCloudWorkspaceBridge();
     }
@@ -137,6 +141,10 @@ export class TestsAppBridges extends AppBridges {
 
     public getUiInteractionBridge(): UiInteractionBridge {
         return this.uiIntegrationBridge;
+    }
+
+    public getNetBridge(): NetBridge {
+        return this.netBridge;
     }
 
     public getSchedulerBridge(): SchedulerBridge {

--- a/tests/test-data/bridges/netBridge.ts
+++ b/tests/test-data/bridges/netBridge.ts
@@ -1,0 +1,7 @@
+import { NetBridge } from '../../../src/server/bridges/NetBridge';
+
+export class TestsNetBridge extends NetBridge {
+    public createConnection(options: object): NodeJS.Socket {
+        throw new Error('Method not implemented.');
+    }
+}


### PR DESCRIPTION
# What? :boat:
This pull request contains an implementation of the bridge to the INet interface. 

# Why? :thinking:
The INet interface adds the ability to create Rocket.Chat applications that uses binary network protocols. At the moment the Apps-Engine limits applications using the one and only HTTP protocol.
