### PR TITLE
[FIX] alternate method name in app.getAppUsername() deprecation notice

### DIFF
--- a/src/definition/App.ts
+++ b/src/definition/App.ts
@@ -63,7 +63,7 @@ export abstract class App implements IApp {
      * @return {string} the username of the app user
      *
      * @deprecated This method will be removed in the next major version.
-     * Please use read.getAppUser instead.
+     * Please use read.getUserReader().getAppUser() instead.
      */
     public getAppUserUsername(): string {
         return `${ this.info.nameSlug }.bot`;


### PR DESCRIPTION
Signed-off-by: Debdut Chakraborty <debdut.chakraborty@rocket.chat>

# What? :boat:
Changed deprecation notice text for `app.getAppUsername()`

# Why? :thinking:
<!--Additional explanation if needed-->

The correct alternative is `read.getUserReader().getAppUser()` not `read.getAppUser()`

https://github.com/RocketChat/Rocket.Chat.Apps-engine/blob/ccc46d087723fa19dafc97a61c202f832316c0ed/src/definition/accessors/IRead.ts#L30

https://github.com/RocketChat/Rocket.Chat.Apps-engine/blob/ccc46d087723fa19dafc97a61c202f832316c0ed/src/definition/accessors/IUserRead.ts#L7-L16

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
