### PR TITLE
[IMPROVE] Move call to store logs to appropriate place

### DIFF
--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -99,9 +99,9 @@ export class ProxiedApp implements IApp {
             if (e instanceof AppsEngineException) {
                 throw e;
             }
+        } finally {
+            this.manager.getLogStorage().storeEntries(this.getID(), logger);
         }
-
-        this.manager.getLogStorage().storeEntries(this.getID(), logger);
 
         return result;
     }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Currently, when an app throws any of the known exceptions that extend `AppsEngineException` to prevent a process from finishing (e.g. `FileUploadNotAllowedException`), the execution re-throws the error object before storing any of the apps logs to the database.

This PR changes this behavior, so that logs are saved regardless of the type of error caught during execution

# Why? :thinking:
<!--Additional explanation if needed-->
Losing the logs limits the debugging capabilities of Apps

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
