### PR TITLE
Add Event Priority to Event Listeners

### DIFF
--- a/src/definition/metadata/EventPriority.ts
+++ b/src/definition/metadata/EventPriority.ts
@@ -1,0 +1,22 @@
+import { App } from '../App';
+
+export enum EventPriority {
+    LOWEST = 0,
+    LOW = 25,
+    NORMAL = 50,
+    HIGH = 75,
+    HIGHEST = 100,
+}
+
+export interface IEventPriorityFunction {
+    priority: EventPriority;
+    (...p: Array<any>): Promise<any>;
+}
+
+export const SetEventPriority = (priority: EventPriority) => (target: App, propertyKey: string, descriptor: TypedPropertyDescriptor<(...p: Array<any>) => Promise<any>>) => {
+    console.log(target.getName(), 'is setting the priority of', propertyKey, 'to a value of', priority);
+
+    ((target as any)[propertyKey] as IEventPriorityFunction).priority = priority;
+
+    return descriptor;
+};

--- a/src/definition/metadata/index.ts
+++ b/src/definition/metadata/index.ts
@@ -4,6 +4,7 @@ import { IAppInfo } from './IAppInfo';
 import { RocketChatAssociationModel, RocketChatAssociationRecord } from './RocketChatAssociations';
 
 export * from './AppInterface';
+export * from './EventPriority';
 
 export {
     AppMethod,

--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -5,7 +5,7 @@ import { App } from '../definition/App';
 import { AppStatus } from '../definition/AppStatus';
 import { AppsEngineException } from '../definition/exceptions';
 import { IApp } from '../definition/IApp';
-import { AppMethod, IAppAuthorInfo, IAppInfo } from '../definition/metadata';
+import { AppMethod, IAppAuthorInfo, IAppInfo, IEventPriorityFunction } from '../definition/metadata';
 import { AppManager } from './AppManager';
 import { NotEnoughMethodArgumentsError } from './errors';
 import { AppConsole } from './logging';
@@ -49,6 +49,14 @@ export class ProxiedApp implements IApp {
 
     public hasMethod(method: AppMethod): boolean {
         return typeof (this.app as any)[method] === 'function';
+    }
+
+    public getMethod(method: AppMethod): IEventPriorityFunction | undefined {
+        if (!this.hasMethod(method)) {
+            return undefined;
+        }
+
+        return (this.app as any)[method];
     }
 
     public makeContext(data: object): vm.Context {


### PR DESCRIPTION
# What? :boat:
- New method decorator which sets the priority of the event

# Why? :thinking:
- So app developers can determine the priority of their listeners (mostly useful for private apps that must have a certain order)

# Links :earth_americas:
#453 

# PS :eyes:
```ts
@SetEventPriority(EventPriority.HIGHEST)
public async executePreMessageSentModify(message: IMessage, builder: IMessageBuilder, read: IRead, http: IHttp, persistence: IPersistence): Promise<IMessage> {
}
```
