### PR TITLE
[NEW] Add new event for pre email

### DIFF
--- a/src/definition/email/IEmailDescriptor.ts
+++ b/src/definition/email/IEmailDescriptor.ts
@@ -1,0 +1,12 @@
+
+export interface IEmailDescriptor {
+    from?: string | undefined;
+    to?: string | Array<string> | undefined;
+    cc?: string | Array<string> | undefined;
+    bcc?: string | Array<string> | undefined;
+    replyTo?: string | Array<string> | undefined;
+    subject?: string | undefined;
+    text?: string | undefined;
+    html?: string | undefined;
+    headers?: Record<string, string> | undefined;
+}

--- a/src/definition/email/IPreEmailSent.ts
+++ b/src/definition/email/IPreEmailSent.ts
@@ -1,0 +1,25 @@
+import { IEmailDescriptor, IPreEmailSentContext } from '.';
+import { IHttp, IModify, IPersistence, IRead } from '../accessors';
+import { AppMethod } from '../metadata';
+
+/**
+ * Event interface that allows apps to
+ * register as a handler of of the `IPreEmailSent`
+ * event.
+ *
+ * This event is trigger before the mailer sends
+ * an email.
+ *
+ * To prevent the email from being sent, you can
+ * throw an error with a message specifying the
+ * reason for rejection.
+ */
+export interface IPreEmailSent {
+    [AppMethod.EXECUTE_PRE_EMAIL_SENT](
+        context: IPreEmailSentContext,
+        read: IRead,
+        http: IHttp,
+        persis: IPersistence,
+        modify: IModify,
+    ): Promise<IEmailDescriptor>;
+}

--- a/src/definition/email/IPreEmailSentContext.ts
+++ b/src/definition/email/IPreEmailSentContext.ts
@@ -1,0 +1,6 @@
+import { IEmailDescriptor } from './IEmailDescriptor';
+
+export interface IPreEmailSentContext {
+    context: unknown;
+    email: IEmailDescriptor;
+}

--- a/src/definition/email/index.ts
+++ b/src/definition/email/index.ts
@@ -1,0 +1,2 @@
+export * from './IEmailDescriptor';
+export * from './IPreEmailSentContext';

--- a/src/definition/metadata/AppInterface.ts
+++ b/src/definition/metadata/AppInterface.ts
@@ -41,4 +41,6 @@ export enum AppInterface {
     IPostLivechatRoomSaved = 'IPostLivechatRoomSaved',
     // FileUpload
     IPreFileUpload = 'IPreFileUpload',
+    // Email
+    IPreEmailSent = 'IPreEmailSent',
 }

--- a/src/definition/metadata/AppMethod.ts
+++ b/src/definition/metadata/AppMethod.ts
@@ -73,4 +73,6 @@ export enum AppMethod {
     EXECUTE_POST_LIVECHAT_ROOM_SAVED = 'executePostLivechatRoomSaved',
     // FileUpload
     EXECUTE_PRE_FILE_UPLOAD = 'executePreFileUpload',
+    // Email
+    EXECUTE_PRE_EMAIL_SENT = 'executePreEmailSent',
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Adds definitions and listener for new event `IPreEmailSent`, that allows for manipulation of email messages sent and interruption of transmission if needed
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
