### PR TITLE
[FIX] Action buttons were not removed from manager

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -266,6 +266,7 @@ export class AppManager {
             } else if (!AppStatusUtils.isError(app.getStatus())) {
                 this.listenerManager.lockEssentialEvents(app);
                 await this.schedulerManager.cleanUp(app.getID());
+                this.uiActionButtonManager.clearAppActionButtons(app.getID());
             }
         }
 
@@ -867,6 +868,7 @@ export class AppManager {
         this.apiManager.unregisterApis(app.getID());
         this.accessorManager.purifyApp(app.getID());
         await this.schedulerManager.cleanUp(app.getID());
+        this.uiActionButtonManager.clearAppActionButtons(app.getID());
     }
 
     /**

--- a/src/server/managers/UIActionButtonManager.ts
+++ b/src/server/managers/UIActionButtonManager.ts
@@ -31,6 +31,7 @@ export class UIActionButtonManager {
 
     public clearAppActionButtons(appId: string) {
         this.registeredActionButtons.set(appId, new Map());
+        this.activationBridge.doActionsChanged();
     }
 
     public getAppActionButtons(appId: string) {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Action buttons, once registered in the button manager, were never removed, even if the app was disabled or uninstalled.

Of course, as the manager itself is kept in memory, restarting the Apps-Engine would have them removed if the app was uninstalled.
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
