### PR TITLE
[FIX] Apps not being enabled in framework load time

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -940,13 +940,14 @@ export class AppManager {
         }
 
         if (saveToDb) {
-            storageItem.status = app.getStatus();
+            storageItem.status = status;
             // This is async, but we don't care since it only updates in the database
             // and it should not mutate any properties we care about
             await this.appMetadataStorage.update(storageItem).catch();
         }
 
         await app.setStatus(status, silenceStatus);
+
         return enable;
     }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
During the procedure to enable an app, the engine wasn't persisting the correct app status to the databasing, causing subsequent calls to `AppManager.load` method (usually called during Rocket.Chat server startup) to leave apps in a "disabled" state
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
