### PR TITLE
[NEW] Adding bridge to change both status and status text

### DIFF
--- a/src/definition/accessors/IUserUpdater.ts
+++ b/src/definition/accessors/IUserUpdater.ts
@@ -11,6 +11,7 @@ import { IUser } from '../users/IUser';
  */
 export interface IUserUpdater {
     updateStatusText(user: IUser, statusText: IUser['statusText']): Promise<boolean>;
+    updateStatus(user: IUser, statusText: IUser['statusText'], status: IUser['status']): Promise<boolean>;
     updateBio(user: IUser, bio: IUser['bio']): Promise<boolean>;
     updateCustomFields(user: IUser, customFields: IUser['customFields']): Promise<boolean>;
 }

--- a/src/server/accessors/UserUpdater.ts
+++ b/src/server/accessors/UserUpdater.ts
@@ -9,6 +9,10 @@ export class UserUpdater implements IUserUpdater {
         return this.bridges.getUserBridge().doUpdate(user, { statusText }, this.appId);
     }
 
+    public async updateStatus(user: IUser, statusText: IUser['statusText'], status: IUser['status']) {
+        return this.bridges.getUserBridge().doUpdate(user, { statusText, status }, this.appId);
+    }
+
     public async updateBio(user: IUser, bio: IUser['bio']) {
         return this.bridges.getUserBridge().doUpdate(user, { bio }, this.appId);
     }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

This PR adds a bridge method to change the status and status text.

# Why? :thinking:
<!--Additional explanation if needed-->
This functionality will help the apps to set custom status better.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
