### PR TITLE
[FIX] App update flow caused slashcommands to run old code

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -634,9 +634,9 @@ export class AppManager {
 
         await this.purgeAppConfig(app);
 
-        await this.runStartUpProcess(stored, app, false, true);
-
         this.apps.set(app.getID(), app);
+
+        await this.runStartUpProcess(stored, app, false, true);
     }
 
     public getLanguageContent(): { [key: string]: object } {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Current update flow caused slash commands registered by apps to retain a reference to the outdated version of the app, essentially failing to update slash command code.

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
