### PR TITLE
[NEW] Allow 'querystring' native module inside apps

### DIFF
--- a/src/server/compiler/modules/index.ts
+++ b/src/server/compiler/modules/index.ts
@@ -13,6 +13,7 @@ export enum AllowedInternalModules {
     util = 'util',
     punycode = 'punycode',
     os = 'os',
+    querystring = 'querystring',
 }
 
 export class ForbiddenNativeModuleAccess extends Error {
@@ -40,6 +41,7 @@ const proxyHandlers = {
     util: defaultHandler,
     punycode: defaultHandler,
     os: noopHandler,
+    querystring: defaultHandler,
 };
 
 export function requireNativeModule(module: AllowedInternalModules, appId: string) {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
In some use cases, apps' dependencies require the module to work properly. For instance the [`oauth`](https://www.npmjs.com/package/oauth) package uses it internally to handle URLs.


# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
https://nodejs.org/docs/latest-v12.x/api/querystring.html
# PS :eyes:
