### PR TITLE
[FIX] Faulty redirect_uri path concatenation

### DIFF
--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -105,7 +105,7 @@ export class OAuth2Client implements IOAuth2Client {
         const url = new URL(authUri, siteUrl);
 
         url.searchParams.set('response_type', 'code');
-        url.searchParams.set('redirect_uri', `${siteUrl}${redirectUri}`);
+        url.searchParams.set('redirect_uri', `${siteUrl}/${redirectUri}`);
         url.searchParams.set('state', user.id);
         url.searchParams.set('client_id', clientId);
         url.searchParams.set('access_type', 'offline');
@@ -177,7 +177,7 @@ export class OAuth2Client implements IOAuth2Client {
 
             url.searchParams.set('client_id', clientId);
             url.searchParams.set('client_secret', clientSecret);
-            url.searchParams.set('redirect_uri', `${siteUrl}${redirectUri}`);
+            url.searchParams.set('redirect_uri', `${siteUrl}/${redirectUri}`);
             url.searchParams.set('refresh_token', tokenInfo.refreshToken);
             url.searchParams.set('grant_type', GrantType.RefreshToken);
 
@@ -209,7 +209,6 @@ export class OAuth2Client implements IOAuth2Client {
             this.app.getLogger().error(error);
             throw error;
         }
-
     }
 
     public async revokeUserAccessToken(user: IUser, persis: IPersistence): Promise<boolean> {
@@ -305,7 +304,7 @@ export class OAuth2Client implements IOAuth2Client {
             const url = new URL(accessTokenUrl, siteUrl);
 
             url.searchParams.set('client_id', clientId);
-            url.searchParams.set('redirect_uri', `${siteUrl}${redirectUri}`);
+            url.searchParams.set('redirect_uri', `${siteUrl}/${redirectUri}`);
             url.searchParams.set('code', code);
             url.searchParams.set('client_secret', clientSecret);
             url.searchParams.set('access_type', 'offline');

--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -240,8 +240,7 @@ export class OAuth2Client implements IOAuth2Client {
             .environmentReader.getServerSettings()
             .getValueById(SITE_URL);
 
-        const lastChar = url.substr(url.length - 1);
-        if (lastChar === '/') {
+        if (url.endsWith('/')) {
             return url.substr(0, url.length - 1);
         }
         return url;

--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -84,10 +84,7 @@ export class OAuth2Client implements IOAuth2Client {
             .getAccessors()
             .providedApiEndpoints[0].computedPath.substring(1);
 
-        const siteUrl = await this.app
-            .getAccessors()
-            .environmentReader.getServerSettings()
-            .getValueById('Site_Url');
+        const siteUrl = await this.getBaseURLWithoutTrailingSlash();
 
         const finalScopes = ([] as Array<string>).concat(
             this.config.defaultScopes || [],
@@ -165,10 +162,8 @@ export class OAuth2Client implements IOAuth2Client {
                 .getSettings()
                 .getValueById(`${this.config.alias}-oauth-clientsecret`);
 
-            const siteUrl = await this.app
-                    .getAccessors()
-                    .environmentReader.getServerSettings()
-                    .getValueById('Site_Url');
+            const siteUrl = await this.getBaseURLWithoutTrailingSlash();
+
             const redirectUri = this.app
                     .getAccessors()
                     .providedApiEndpoints[0].computedPath.substring(1);
@@ -238,6 +233,20 @@ export class OAuth2Client implements IOAuth2Client {
         }
     }
 
+    private async getBaseURLWithoutTrailingSlash(): Promise<string> {
+        const SITE_URL = 'Site_Url';
+        const url = await this.app
+            .getAccessors()
+            .environmentReader.getServerSettings()
+            .getValueById(SITE_URL);
+
+        const lastChar = url.substr(url.length - 1);
+        if (lastChar === '/') {
+            return url.substr(0, url.length - 1);
+        }
+        return url;
+    }
+
     private async handleOAuthCallback(
         request: IApiRequest,
         endpoint: IApiEndpointInfo,
@@ -278,10 +287,7 @@ export class OAuth2Client implements IOAuth2Client {
                 };
             }
 
-            const siteUrl = await this.app
-                .getAccessors()
-                .environmentReader.getServerSettings()
-                .getValueById('Site_Url');
+            const siteUrl = await this.getBaseURLWithoutTrailingSlash();
 
             const accessTokenUrl = this.config.accessTokenUri;
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
During the OAuth process, the `redirect_uri` wasn't being formatted properly, making the login process fail. 

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
