### PR TITLE
[NEW] Get user's preferred language via apps

### DIFF
--- a/src/definition/users/IUser.ts
+++ b/src/definition/users/IUser.ts
@@ -1,6 +1,7 @@
 import { IUserEmail } from './IUserEmail';
 import { UserStatusConnection } from './UserStatusConnection';
 import { UserType } from './UserType';
+import { IUserSettings } from './IUserSettings';
 
 export interface IUser {
     id: string;
@@ -18,7 +19,7 @@ export interface IUser {
     createdAt: Date;
     updatedAt: Date;
     lastLoginAt: Date;
-    userPreferredLanguage?: string;
+    settings?: IUserSettings;
     appId?: string;
     customFields?: { [key: string]: any };
 }

--- a/src/definition/users/IUser.ts
+++ b/src/definition/users/IUser.ts
@@ -1,7 +1,7 @@
 import { IUserEmail } from './IUserEmail';
+import { IUserSettings } from './IUserSettings';
 import { UserStatusConnection } from './UserStatusConnection';
 import { UserType } from './UserType';
-import { IUserSettings } from './IUserSettings';
 
 export interface IUser {
     id: string;

--- a/src/definition/users/IUser.ts
+++ b/src/definition/users/IUser.ts
@@ -18,6 +18,7 @@ export interface IUser {
     createdAt: Date;
     updatedAt: Date;
     lastLoginAt: Date;
+    userPreferredLanguage?: string;
     appId?: string;
     customFields?: { [key: string]: any };
 }

--- a/src/definition/users/IUserSettings.ts
+++ b/src/definition/users/IUserSettings.ts
@@ -1,0 +1,5 @@
+export interface IUserSettings {
+    preferences?: { 
+        language?: string;
+    }
+}

--- a/src/definition/users/IUserSettings.ts
+++ b/src/definition/users/IUserSettings.ts
@@ -1,5 +1,5 @@
 export interface IUserSettings {
-    preferences?: { 
+    preferences?: {
         language?: string;
-    }
+    };
 }

--- a/src/server/accessors/UserBuilder.ts
+++ b/src/server/accessors/UserBuilder.ts
@@ -1,6 +1,7 @@
 import { IUserBuilder } from '../../definition/accessors';
 import { RocketChatAssociationModel } from '../../definition/metadata';
 import { IUser, IUserEmail } from '../../definition/users';
+import { IUserSettings } from '../../definition/users/IUserSettings';
 
 export class UserBuilder implements IUserBuilder {
     public kind: RocketChatAssociationModel.USER;
@@ -55,10 +56,8 @@ export class UserBuilder implements IUserBuilder {
         return this.user.roles;
     }
 
-    // Note: if the user doesn't have a preferred language set, then this will return undefined
-    // In that case, use the default language of the Rocket.Chat server from the server settings
-    public getPreferredLanguage(): string | undefined {
-        return this.user.userPreferredLanguage;
+    public getSettings(): Partial<IUserSettings> {
+        return this.user.settings;
     }
 
     public getUser(): Partial<IUser> {

--- a/src/server/accessors/UserBuilder.ts
+++ b/src/server/accessors/UserBuilder.ts
@@ -55,6 +55,12 @@ export class UserBuilder implements IUserBuilder {
         return this.user.roles;
     }
 
+    // Note: if the user doesn't have a preferred language set, then this will return undefined
+    // In that case, use the default language of the Rocket.Chat server from the server settings
+    public getPreferredLanguage(): string | undefined {
+        return this.user.userPreferredLanguage;
+    }
+
     public getUser(): Partial<IUser> {
         if (!this.user.username) {
             throw new Error('The "username" property is required.');


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

Exposed a new property on the User object that allows apps to read the user's preferred language

# Why? :thinking:
<!--Additional explanation if needed-->

So that apps can provide a more personalized experience :rocket: 

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
Connected core PR: https://github.com/RocketChat/Rocket.Chat/pull/25514