### PR TITLE
[NEW] Add url prop in the OptionObject

### DIFF
--- a/src/definition/uikit/blocks/Objects.ts
+++ b/src/definition/uikit/blocks/Objects.ts
@@ -19,4 +19,6 @@ export interface ITextObject {
 export interface IOptionObject {
     text: ITextObject;
     value: string;
+
+    url?: string;
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Added URL to the options object to allow the Overflow component to open it.

# Why? :thinking:
<!--Additional explanation if needed-->
This feature will allow opening a link inside the overflow component, as it's possible with the button component. We will need it to develop the Google Drive app.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
[Task](https://app.clickup.com/t/2mkhme4)

# PS :eyes:
