### PR TITLE
[NEW] Enable authenticated endpoints

### DIFF
--- a/src/definition/api/IApi.ts
+++ b/src/definition/api/IApi.ts
@@ -1,4 +1,3 @@
-import { ApiEndpoint } from './ApiEndpoint';
 import { IApiEndpoint } from './IApiEndpoint';
 
 /**
@@ -16,7 +15,7 @@ export interface IApi {
     /**
      * Provide enpoints for this api registry
      */
-    endpoints: Array<ApiEndpoint | IApiEndpoint>;
+    endpoints: Array<IApiEndpoint>;
 }
 
 export enum ApiVisibility {
@@ -55,6 +54,5 @@ export enum ApiSecurity {
      * will be generated automatically.
      * @param `X-Auth-Token`
      */
-    // AUTH_TOKEN,
     // CHECKSUM_SECRET,
 }

--- a/src/definition/api/IApiEndpoint.ts
+++ b/src/definition/api/IApiEndpoint.ts
@@ -14,6 +14,13 @@ export interface IApiEndpoint {
      */
     path: string;
     examples?: {[key: string]: IApiExample};
+    /**
+     * Whether this endpoint requires an authenticated user to access it.
+     *
+     * The authentication will be done by the host server using its own
+     * authentication system.
+     */
+    authRequired?: boolean;
 
     /**
      * Called whenever the publically accessible url for this App is called,

--- a/src/definition/api/IRequest.ts
+++ b/src/definition/api/IRequest.ts
@@ -1,4 +1,5 @@
 import { RequestMethod } from '../accessors';
+import { IUser } from '../users';
 
 export interface IApiRequest {
     method: RequestMethod;
@@ -7,4 +8,10 @@ export interface IApiRequest {
     params: { [key: string]: string };
     content: any;
     privateHash?: string;
+    /**
+     * The user that is making the request.
+     * Available if the endpoint has property
+     * `authRequired` set to `true`.
+     */
+    user?: IUser;
 }

--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.32.0-alpha",
+  "version": "1.33.0-alpha",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Adds properties to IApiEndpoint that allows apps to request an endpoint only be accessed by a request authenticated by Rocket.Chat
# Why? :thinking:
<!--Additional explanation if needed-->
Authentication here provides some kind of trust to the app the it is a user of the current workspace who is trying to access the resource
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
