### PR TITLE
[NEW] allow dispatchment of actions from input elements

### DIFF
--- a/src/definition/uikit/blocks/Elements.ts
+++ b/src/definition/uikit/blocks/Elements.ts
@@ -11,6 +11,7 @@ export enum BlockElementType {
 
 export enum InputElementDispatchAction {
     ON_CHARACTER_ENTERED = 'on_character_entered',
+    ON_ITEM_SELECTED = 'on_item_selected',
 }
 
 export interface IBlockElement {

--- a/src/definition/uikit/blocks/Elements.ts
+++ b/src/definition/uikit/blocks/Elements.ts
@@ -28,7 +28,7 @@ export interface IInputElement extends IBlockElement {
     actionId: string;
     placeholder: ITextObject;
     initialValue?: string | Array<string>;
-    dispatchActionConfig?: InputElementDispatchAction[];
+    dispatchActionConfig?: Array<InputElementDispatchAction>;
 }
 
 export enum ButtonStyle {

--- a/src/definition/uikit/blocks/Elements.ts
+++ b/src/definition/uikit/blocks/Elements.ts
@@ -9,6 +9,10 @@ export enum BlockElementType {
     MULTI_STATIC_SELECT = 'multi_static_select',
 }
 
+export enum InputElementDispatchAction {
+    ON_CHARACTER_ENTERED = 'on_character_entered',
+}
+
 export interface IBlockElement {
     type: BlockElementType;
 }
@@ -23,6 +27,7 @@ export interface IInputElement extends IBlockElement {
     actionId: string;
     placeholder: ITextObject;
     initialValue?: string | Array<string>;
+    dispatchActionConfig?: InputElementDispatchAction[];
 }
 
 export enum ButtonStyle {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Added a new property to `input elements` so actions can be triggered based on user activity.

https://user-images.githubusercontent.com/733282/174858175-5ea53046-c791-493e-859b-b80431e94ffa.mp4

[Test app used in the video](https://github.com/RocketChat/apps-pocs-and-tests/tree/main/input-element-block-action)

# Why? :thinking:
<!--Additional explanation if needed-->
This is needed for the development of the Google Drive app.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
Related PRs:
- https://github.com/RocketChat/fuselage/pull/747
- https://github.com/RocketChat/Rocket.Chat/pull/25949

# PS :eyes:
