### PR TITLE
Keeping schedulers after disabling an app

### DIFF
--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.32.0-alpha",
+  "version": "1.33.0-alpha",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -406,7 +406,7 @@ export class AppManager {
                 .catch((e) => console.warn('Error while disabling:', e));
         }
 
-        await this.purgeAppConfig(app);
+        await this.purgeAppConfig(app, true);
 
         await app.setStatus(status, silent);
 
@@ -860,7 +860,10 @@ export class AppManager {
         return result;
     }
 
-    private async purgeAppConfig(app: ProxiedApp) {
+    private async purgeAppConfig(app: ProxiedApp, isDisabled: boolean = false) {
+        if (!isDisabled) {
+            await this.schedulerManager.cleanUp(app.getID());
+        }
         this.listenerManager.unregisterListeners(app);
         this.listenerManager.lockEssentialEvents(app);
         this.commandManager.unregisterCommands(app.getID());

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -265,7 +265,6 @@ export class AppManager {
                 await this.enableApp(items.get(app.getID()), app, true, app.getPreviousStatus() === AppStatus.MANUALLY_ENABLED).catch(console.error);
             } else if (!AppStatusUtils.isError(app.getStatus())) {
                 this.listenerManager.lockEssentialEvents(app);
-                await this.schedulerManager.cleanUp(app.getID());
                 this.uiActionButtonManager.clearAppActionButtons(app.getID());
             }
         }
@@ -868,7 +867,6 @@ export class AppManager {
         this.externalComponentManager.unregisterExternalComponents(app.getID());
         this.apiManager.unregisterApis(app.getID());
         this.accessorManager.purifyApp(app.getID());
-        await this.schedulerManager.cleanUp(app.getID());
         this.uiActionButtonManager.clearAppActionButtons(app.getID());
     }
 

--- a/src/server/managers/AppSchedulerManager.ts
+++ b/src/server/managers/AppSchedulerManager.ts
@@ -1,3 +1,4 @@
+import { AppStatus } from '../../definition/AppStatus';
 import { AppMethod } from '../../definition/metadata';
 import {
     IJobContext,
@@ -53,6 +54,14 @@ export class AppSchedulerManager {
             }
 
             const app = this.manager.getOneById(appId);
+            const status = app.getStatus();
+            const previousStatus = app.getPreviousStatus();
+
+            const isNotToRunJob = this.isNotToRunJob(status, previousStatus);
+
+            if (isNotToRunJob) {
+                return;
+            }
 
             const context = app.makeContext({
                 processor,
@@ -101,5 +110,12 @@ export class AppSchedulerManager {
 
     public async cleanUp(appId: string): Promise<void> {
         (this.bridge as IInternalSchedulerBridge & SchedulerBridge).cancelAllJobs(appId);
+    }
+
+    private isNotToRunJob(status: AppStatus, previousStatus: AppStatus): boolean {
+        const isAppCurrentDisabled = status === AppStatus.DISABLED || status === AppStatus.MANUALLY_DISABLED;
+        const wasAppDisabled = previousStatus === AppStatus.DISABLED || previousStatus === AppStatus.MANUALLY_DISABLED;
+
+        return (status === AppStatus.INITIALIZED && wasAppDisabled) || isAppCurrentDisabled;
     }
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
This PR changes the logic behind when an app is disabled to keep the schedulers saved
# Why? :thinking:
<!--Additional explanation if needed-->
Currently, whenever an app is disabled, all the jobs it scheduled are deleted from the database. However, this causes confusion if the app is re-enabled, as users will expect jobs scheduled previously to run anyways.
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
