### PR TITLE
[NEW] allow to pass the id for ephemeral messages

### DIFF
--- a/src/definition/accessors/INotifier.ts
+++ b/src/definition/accessors/INotifier.ts
@@ -38,7 +38,7 @@ export interface INotifier {
      * @param user The user who should be notified
      * @param message The message with the content to notify the user about
      */
-    notifyUser(user: IUser, message: IMessage): Promise<void>;
+    notifyUser(user: IUser, message: IMessage, messageId?: string): Promise<void>;
 
     /**
      * Notifies all of the users in the provided room.

--- a/src/server/accessors/Notifier.ts
+++ b/src/server/accessors/Notifier.ts
@@ -13,14 +13,14 @@ export class Notifier implements INotifier {
         private readonly appId: string,
     ) { }
 
-    public async notifyUser(user: IUser, message: IMessage): Promise<void> {
+    public async notifyUser(user: IUser, message: IMessage, messageId?: string): Promise<void> {
         if (!message.sender || !message.sender.id) {
             const appUser = await this.userBridge.doGetAppUser(this.appId);
 
             message.sender = appUser;
         }
 
-        await this.msgBridge.doNotifyUser(user, message, this.appId);
+        await this.msgBridge.doNotifyUser(user, message, this.appId, messageId);
     }
 
     public async notifyRoom(room: IRoom, message: IMessage): Promise<void> {

--- a/src/server/bridges/MessageBridge.ts
+++ b/src/server/bridges/MessageBridge.ts
@@ -24,9 +24,9 @@ export abstract class MessageBridge extends BaseBridge {
         }
     }
 
-    public async doNotifyUser(user: IUser, message: IMessage, appId: string): Promise<void> {
+    public async doNotifyUser(user: IUser, message: IMessage, appId: string, messageId?: string): Promise<void> {
         if (this.hasWritePermission(appId)) {
-            return this.notifyUser(user, message, appId);
+            return this.notifyUser(user, message, appId, messageId);
         }
     }
 
@@ -50,7 +50,7 @@ export abstract class MessageBridge extends BaseBridge {
 
     protected abstract create(message: IMessage, appId: string): Promise<string>;
     protected abstract update(message: IMessage, appId: string): Promise<void>;
-    protected abstract notifyUser(user: IUser, message: IMessage, appId: string): Promise<void>;
+    protected abstract notifyUser(user: IUser, message: IMessage, appId: string, messageId?: string): Promise<void>;
     protected abstract notifyRoom(room: IRoom, message: IMessage, appId: string): Promise<void>;
     protected abstract typing(options: ITypingDescriptor, appId: string): Promise<void>;
     protected abstract getById(messageId: string, appId: string): Promise<IMessage>;


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Added the possibility to pass an ID for ephemeral messages. This way, you could use the same ID to edit the message.

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
[Rocket.chat PR](https://github.com/RocketChat/Rocket.Chat/pull/26118)

# PS :eyes:
