### PR TITLE
[FIX] Keep scheduled jobs when updating an app

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -39,6 +39,10 @@ export interface IAppManagerDeps {
     sourceStorage: AppSourceStorage;
 }
 
+interface IPurgeAppConfigOpts {
+    keepScheduledJobs?: boolean;
+}
+
 export class AppManager {
     public static Instance: AppManager;
 
@@ -412,7 +416,7 @@ export class AppManager {
                 .catch((e) => console.warn('Error while disabling:', e));
         }
 
-        await this.purgeAppConfig(app, true);
+        await this.purgeAppConfig(app, { keepScheduledJobs: true });
 
         await app.setStatus(status, silent);
 
@@ -637,7 +641,7 @@ export class AppManager {
             return appPackageOrInstance;
         })();
 
-        await this.purgeAppConfig(app);
+        await this.purgeAppConfig(app, { keepScheduledJobs: true });
 
         this.apps.set(app.getID(), app);
 
@@ -866,8 +870,8 @@ export class AppManager {
         return result;
     }
 
-    private async purgeAppConfig(app: ProxiedApp, isDisabled: boolean = false) {
-        if (!isDisabled) {
+    private async purgeAppConfig(app: ProxiedApp, opts: IPurgeAppConfigOpts = {}) {
+        if (!opts.keepScheduledJobs) {
             await this.schedulerManager.cleanUp(app.getID());
         }
         this.listenerManager.unregisterListeners(app);


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
- Make the _update app_ action work in the same way as _disable app_ when it comes to keeping scheduled jobs in the db and not deleting them.

# Why? :thinking:
<!--Additional explanation if needed-->
Way to reproduce:
- use the test app [agenda4test](https://github.com/RocketChat/apps-pocs-and-tests/tree/main/agendav4test) to schedule a job by running the slash command `/scheduler r` (this will create a job that runs every 10 seconds and posts a message to the _general channel_)
- disable app and then enable it again (still works);
- update the app via cli or zip file (this is where the patched code does its job; the task will keep running as it should);
- uninstall the app (no leftover data in the database)

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
