### PR TITLE
[FIX] Set message editor prop by default on updates

### DIFF
--- a/src/server/accessors/ModifyUpdater.ts
+++ b/src/server/accessors/ModifyUpdater.ts
@@ -29,7 +29,7 @@ export class ModifyUpdater implements IModifyUpdater {
     public async message(messageId: string, updater: IUser): Promise<IMessageBuilder> {
         const msg = await this.bridges.getMessageBridge().doGetById(messageId, this.appId);
 
-        return new MessageBuilder(msg);
+        return new MessageBuilder(msg).setEditor(updater);
     }
 
     public async room(roomId: string, updater: IUser): Promise<IRoomBuilder> {
@@ -58,6 +58,10 @@ export class ModifyUpdater implements IModifyUpdater {
 
         if (!result.sender || !result.sender.id) {
             throw new Error('Invalid sender assigned to the message.');
+        }
+
+        if (!result.editor || !result.editor.id) {
+            throw new Error('Invalid editor assigned to the message.');
         }
 
         return this.bridges.getMessageBridge().doUpdate(result, this.appId);

--- a/tests/server/accessors/ModifyUpdater.spec.ts
+++ b/tests/server/accessors/ModifyUpdater.spec.ts
@@ -73,6 +73,10 @@ export class ModifyUpdaterTestFixture {
         msgBd.setSender(TestData.getUser());
         Expect(msg.sender).toBeDefined();
 
+        await Expect(async () => await mc.finish(msgBd)).toThrowErrorAsync(Error, 'Invalid editor assigned to the message.');
+        msgBd.setEditor(TestData.getUser());
+        Expect(msg.editor).toBeDefined();
+
         const msgBriSpy = SpyOn(this.mockMessageBridge, 'doUpdate');
         Expect(await mc.finish(msgBd)).not.toBeDefined();
         Expect(msgBriSpy).toHaveBeenCalledWith(msg, this.mockAppId);


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
When calling the method `modify.getUpdater().message(messageId, user)`, the `user` property wasn't being used.  

# Why? :thinking:
<!--Additional explanation if needed-->
As the property is needed when updating a message, [the server throws an error](https://github.com/RocketChat/Rocket.Chat/blob/10932a5356e4eb259fa98984aaf88f99a6085772/apps/meteor/app/apps/server/bridges/messages.ts#L41) and crashes.

<details>
  <summary>Example app code that raises the issue</summary>
  
  ```typescript
  async function updateMessage(modify: IModify, user: IUser, messageId: string): Promise<void> {
    const messageBuilder = await modify.getUpdater().message(messageId, user);

    const oldMessageText = messageBuilder.getText();

    const newMessageText = `${oldMessageText}\nUPDATE: this message got updated at ${new Date()}`;

    messageBuilder.setText(newMessageText);

    await modify.getUpdater().finish(messageBuilder);
}

  ```
</details>

<details>
  <summary>Error messages</summary>

```
W20220825-17:19:06.265(-3)? (STDERR) === UnHandledPromiseRejection ===
W20220825-17:19:06.267(-3)? (STDERR) Error: Invalid editor assigned to the message for the update.
W20220825-17:19:06.267(-3)? (STDERR)     at app/apps/server/bridges/messages.ts:43:10
W20220825-17:19:06.267(-3)? (STDERR)     at /<REDACTED>/.meteor/packages/promise/.0.12.0.awlna7.wkccv++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
W20220825-17:19:06.267(-3)? (STDERR)     at Object.pe [as messagesBridgeUsageSimulation] (evalmachine.<anonymous>:2:556)
W20220825-17:19:06.267(-3)? (STDERR) ---------------------------------
W20220825-17:19:06.267(-3)? (STDERR) Errors like this can cause oplog processing errors.
W20220825-17:19:06.268(-3)? (STDERR) Setting EXIT_UNHANDLEDPROMISEREJECTION will cause the process to exit allowing your service to automatically restart the process
W20220825-17:19:06.268(-3)? (STDERR) Future node.js versions will automatically exit the process
W20220825-17:19:06.268(-3)? (STDERR) =================================
```

Followed by:

```
W20220825-17:19:19.741(-3)? (STDERR) Error: the worker has exited
W20220825-17:19:19.743(-3)? (STDERR)     at ThreadStream.write (/REDACTED/apps/meteor/node_modules/thread-stream/index.js:214:13)
W20220825-17:19:19.743(-3)? (STDERR)     at Pino.write (/REDACTED/apps/meteor/node_modules/pino/lib/proto.js:208:10)
W20220825-17:19:19.744(-3)? (STDERR)     at Pino.LOG (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:58:21)
W20220825-17:19:19.745(-3)? (STDERR)     at Pino.logMethod (server/lib/logger/getPino.ts:13:16)
W20220825-17:19:19.746(-3)? (STDERR)     at Pino.hookWrappedLog [as http] (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:38:10)
W20220825-17:19:19.746(-3)? (STDERR)     at Object._internalRouteActionHandler [as action] (app/api/server/api.js:478:11)
W20220825-17:19:19.746(-3)? (STDERR)     at Route._callEndpoint (packages/rocketchat_restivus/lib/route.coffee:150:32)
W20220825-17:19:19.746(-3)? (STDERR)     at packages/rocketchat_restivus/lib/route.coffee:59:33
W20220825-17:19:19.747(-3)? (STDERR)     at packages/simple_json-routes.js:100:9
W20220825-17:19:20.830(-3)? (STDERR) Error: the worker has exited
W20220825-17:19:20.831(-3)? (STDERR)     at ThreadStream.write (/REDACTED/apps/meteor/node_modules/thread-stream/index.js:214:13)
W20220825-17:19:20.832(-3)? (STDERR)     at Pino.write (/REDACTED/apps/meteor/node_modules/pino/lib/proto.js:208:10)
W20220825-17:19:20.832(-3)? (STDERR)     at Pino.LOG (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:58:21)
W20220825-17:19:20.833(-3)? (STDERR)     at Pino.logMethod (server/lib/logger/getPino.ts:13:16)
W20220825-17:19:20.833(-3)? (STDERR)     at Pino.hookWrappedLog [as http] (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:38:10)
W20220825-17:19:20.833(-3)? (STDERR)     at Object._internalRouteActionHandler [as action] (app/api/server/api.js:478:11)
W20220825-17:19:20.834(-3)? (STDERR)     at Route._callEndpoint (packages/rocketchat_restivus/lib/route.coffee:150:32)
W20220825-17:19:20.834(-3)? (STDERR)     at packages/rocketchat_restivus/lib/route.coffee:59:33
W20220825-17:19:20.835(-3)? (STDERR)     at packages/simple_json-routes.js:100:9
W20220825-17:19:22.870(-3)? (STDERR) Error: the worker has exited
W20220825-17:19:22.872(-3)? (STDERR)     at ThreadStream.write (/REDACTED/apps/meteor/node_modules/thread-stream/index.js:214:13)
W20220825-17:19:22.872(-3)? (STDERR)     at Pino.write (/REDACTED/apps/meteor/node_modules/pino/lib/proto.js:208:10)
W20220825-17:19:22.873(-3)? (STDERR)     at Pino.LOG (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:58:21)
W20220825-17:19:22.873(-3)? (STDERR)     at Pino.logMethod (server/lib/logger/getPino.ts:13:16)
W20220825-17:19:22.873(-3)? (STDERR)     at Pino.hookWrappedLog [as http] (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:38:10)
W20220825-17:19:22.874(-3)? (STDERR)     at Object._internalRouteActionHandler [as action] (app/api/server/api.js:478:11)
W20220825-17:19:22.874(-3)? (STDERR)     at Route._callEndpoint (packages/rocketchat_restivus/lib/route.coffee:150:32)
W20220825-17:19:22.875(-3)? (STDERR)     at packages/rocketchat_restivus/lib/route.coffee:59:33
W20220825-17:19:22.875(-3)? (STDERR)     at packages/simple_json-routes.js:100:9
W20220825-17:19:26.921(-3)? (STDERR) Error: the worker has exited
W20220825-17:19:26.922(-3)? (STDERR)     at ThreadStream.write (/REDACTED/apps/meteor/node_modules/thread-stream/index.js:214:13)
W20220825-17:19:26.923(-3)? (STDERR)     at Pino.write (/REDACTED/apps/meteor/node_modules/pino/lib/proto.js:208:10)
W20220825-17:19:26.923(-3)? (STDERR)     at Pino.LOG (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:58:21)
W20220825-17:19:26.924(-3)? (STDERR)     at Pino.logMethod (server/lib/logger/getPino.ts:13:16)
W20220825-17:19:26.924(-3)? (STDERR)     at Pino.hookWrappedLog [as http] (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:38:10)
W20220825-17:19:26.924(-3)? (STDERR)     at Object._internalRouteActionHandler [as action] (app/api/server/api.js:478:11)
W20220825-17:19:26.925(-3)? (STDERR)     at Route._callEndpoint (packages/rocketchat_restivus/lib/route.coffee:150:32)
W20220825-17:19:26.925(-3)? (STDERR)     at packages/rocketchat_restivus/lib/route.coffee:59:33
W20220825-17:19:26.925(-3)? (STDERR)     at packages/simple_json-routes.js:100:9
W20220825-17:19:36.957(-3)? (STDERR) Error: the worker has exited
W20220825-17:19:36.957(-3)? (STDERR)     at ThreadStream.write (/REDACTED/apps/meteor/node_modules/thread-stream/index.js:214:13)
W20220825-17:19:36.958(-3)? (STDERR)     at Pino.write (/REDACTED/apps/meteor/node_modules/pino/lib/proto.js:208:10)
W20220825-17:19:36.958(-3)? (STDERR)     at Pino.LOG (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:58:21)
W20220825-17:19:36.958(-3)? (STDERR)     at Pino.logMethod (server/lib/logger/getPino.ts:13:16)
W20220825-17:19:36.958(-3)? (STDERR)     at Pino.hookWrappedLog [as http] (/REDACTED/apps/meteor/node_modules/pino/lib/tools.js:38:10)
W20220825-17:19:36.959(-3)? (STDERR)     at Object._internalRouteActionHandler [as action] (app/api/server/api.js:478:11)
W20220825-17:19:36.959(-3)? (STDERR)     at Route._callEndpoint (packages/rocketchat_restivus/lib/route.coffee:150:32)
W20220825-17:19:36.959(-3)? (STDERR)     at packages/rocketchat_restivus/lib/route.coffee:59:33
W20220825-17:19:36.959(-3)? (STDERR)     at packages/simple_json-routes.js:100:9

```

</details>

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
