### PR TITLE
[FEAT] Assign ids to blocks and elements

### DIFF
--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.33.0-alpha",
+  "version": "1.35.0-alpha",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",

--- a/src/server/accessors/ModifyCreator.ts
+++ b/src/server/accessors/ModifyCreator.ts
@@ -1,5 +1,3 @@
-import { Block } from '@rocket.chat/ui-kit';
-import { v4 as uuid } from 'uuid';
 import {
     IDiscussionBuilder,
     ILivechatCreator,
@@ -14,9 +12,10 @@ import { ILivechatMessage } from '../../definition/livechat/ILivechatMessage';
 import { IMessage } from '../../definition/messages';
 import { RocketChatAssociationModel } from '../../definition/metadata';
 import { IRoom, RoomType } from '../../definition/rooms';
-import { BlockBuilder, IBlock } from '../../definition/uikit';
+import { BlockBuilder } from '../../definition/uikit';
 import { AppVideoConference } from '../../definition/videoConferences';
 import { AppBridges } from '../bridges';
+import { UIHelper } from '../misc/UIHelper';
 import { DiscussionBuilder } from './DiscussionBuilder';
 import { LivechatCreator } from './LivechatCreator';
 import { LivechatMessageBuilder } from './LivechatMessageBuilder';
@@ -117,7 +116,7 @@ export class ModifyCreator implements IModifyCreator {
         }
 
         if (result.blocks?.length) {
-            result.blocks = this._assignIds(result.blocks);
+            result.blocks = UIHelper.assignIds(result.blocks, this.appId);
         }
 
         return this.bridges.getMessageBridge().doCreate(result, this.appId);
@@ -215,24 +214,4 @@ export class ModifyCreator implements IModifyCreator {
 
         return this.bridges.getVideoConferenceBridge().doCreate(videoConference, this.appId);
     }
-
-    private _assignIds(blocks: Array<IBlock | Block>): Array<IBlock | Block> {
-        blocks.forEach((block: (IBlock | Block) & { appId?: string, blockId?: string, elements?: Array<any> }) => {
-             if (!block.appId) {
-                 block.appId = this.appId;
-             }
-             if (!block.blockId) {
-                 block.blockId = uuid();
-             }
-             if (block.elements) {
-                 block.elements.forEach((element) => {
-                     if (!element.actionId) {
-                         element.actionId = uuid();
-                     }
-                 });
-             }
-         });
-
-        return blocks;
-     }
 }

--- a/src/server/accessors/ModifyCreator.ts
+++ b/src/server/accessors/ModifyCreator.ts
@@ -1,3 +1,5 @@
+import { Block } from '@rocket.chat/ui-kit';
+import { v4 as uuid } from 'uuid';
 import {
     IDiscussionBuilder,
     ILivechatCreator,
@@ -12,7 +14,7 @@ import { ILivechatMessage } from '../../definition/livechat/ILivechatMessage';
 import { IMessage } from '../../definition/messages';
 import { RocketChatAssociationModel } from '../../definition/metadata';
 import { IRoom, RoomType } from '../../definition/rooms';
-import { BlockBuilder } from '../../definition/uikit';
+import { BlockBuilder, IBlock } from '../../definition/uikit';
 import { AppVideoConference } from '../../definition/videoConferences';
 import { AppBridges } from '../bridges';
 import { DiscussionBuilder } from './DiscussionBuilder';
@@ -114,6 +116,10 @@ export class ModifyCreator implements IModifyCreator {
             result.sender = appUser;
         }
 
+        if (result.blocks?.length) {
+            result.blocks = this._assignIds(result.blocks);
+        }
+
         return this.bridges.getMessageBridge().doCreate(result, this.appId);
     }
 
@@ -209,4 +215,24 @@ export class ModifyCreator implements IModifyCreator {
 
         return this.bridges.getVideoConferenceBridge().doCreate(videoConference, this.appId);
     }
+
+    private _assignIds(blocks: Array<IBlock | Block>): Array<IBlock | Block> {
+        blocks.forEach((block: (IBlock | Block) & { appId?: string, blockId?: string, elements?: Array<any> }) => {
+             if (!block.appId) {
+                 block.appId = this.appId;
+             }
+             if (!block.blockId) {
+                 block.blockId = uuid();
+             }
+             if (block.elements) {
+                 block.elements.forEach((element) => {
+                     if (!element.actionId) {
+                         element.actionId = uuid();
+                     }
+                 });
+             }
+         });
+
+        return blocks;
+     }
 }

--- a/src/server/accessors/ModifyUpdater.ts
+++ b/src/server/accessors/ModifyUpdater.ts
@@ -1,7 +1,10 @@
+import { Block } from '@rocket.chat/ui-kit';
+import { v4 as uuid } from 'uuid';
 import { ILivechatUpdater, IMessageBuilder, IModifyUpdater, IRoomBuilder } from '../../definition/accessors';
 import { IUserUpdater } from '../../definition/accessors/IUserUpdater';
 import { RocketChatAssociationModel } from '../../definition/metadata';
 import { RoomType } from '../../definition/rooms';
+import { IBlock } from '../../definition/uikit';
 import { IUser } from '../../definition/users';
 import { AppBridges } from '../bridges';
 import { LivechatUpdater } from './LivechatUpdater';
@@ -60,6 +63,10 @@ export class ModifyUpdater implements IModifyUpdater {
             throw new Error('Invalid sender assigned to the message.');
         }
 
+        if (result.blocks?.length) {
+            result.blocks = this._assignIds(result.blocks);
+        }
+
         return this.bridges.getMessageBridge().doUpdate(result, this.appId);
     }
 
@@ -89,5 +96,25 @@ export class ModifyUpdater implements IModifyUpdater {
         }
 
         return this.bridges.getRoomBridge().doUpdate(result, builder.getMembersToBeAddedUsernames(), this.appId);
+    }
+
+    private _assignIds(blocks: Array<IBlock | Block>): Array<IBlock | Block> {
+       blocks.forEach((block: (IBlock | Block) & { appId?: string, blockId?: string, elements?: Array<any> }) => {
+            if (!block.appId) {
+                block.appId = this.appId;
+            }
+            if (!block.blockId) {
+                block.blockId = uuid();
+            }
+            if (block.elements) {
+                block.elements.forEach((element) => {
+                    if (!element.actionId) {
+                        element.actionId = uuid();
+                    }
+                });
+            }
+        });
+
+       return blocks;
     }
 }

--- a/src/server/accessors/ModifyUpdater.ts
+++ b/src/server/accessors/ModifyUpdater.ts
@@ -1,12 +1,10 @@
-import { Block } from '@rocket.chat/ui-kit';
-import { v4 as uuid } from 'uuid';
 import { ILivechatUpdater, IMessageBuilder, IModifyUpdater, IRoomBuilder } from '../../definition/accessors';
 import { IUserUpdater } from '../../definition/accessors/IUserUpdater';
 import { RocketChatAssociationModel } from '../../definition/metadata';
 import { RoomType } from '../../definition/rooms';
-import { IBlock } from '../../definition/uikit';
 import { IUser } from '../../definition/users';
 import { AppBridges } from '../bridges';
+import { UIHelper } from '../misc/UIHelper';
 import { LivechatUpdater } from './LivechatUpdater';
 import { MessageBuilder } from './MessageBuilder';
 import { RoomBuilder } from './RoomBuilder';
@@ -64,7 +62,8 @@ export class ModifyUpdater implements IModifyUpdater {
         }
 
         if (result.blocks?.length) {
-            result.blocks = this._assignIds(result.blocks);
+            result.blocks = UIHelper.assignIds(result.blocks, this.appId);
+            // result.blocks = this._assignIds(result.blocks);
         }
 
         return this.bridges.getMessageBridge().doUpdate(result, this.appId);
@@ -98,23 +97,4 @@ export class ModifyUpdater implements IModifyUpdater {
         return this.bridges.getRoomBridge().doUpdate(result, builder.getMembersToBeAddedUsernames(), this.appId);
     }
 
-    private _assignIds(blocks: Array<IBlock | Block>): Array<IBlock | Block> {
-       blocks.forEach((block: (IBlock | Block) & { appId?: string, blockId?: string, elements?: Array<any> }) => {
-            if (!block.appId) {
-                block.appId = this.appId;
-            }
-            if (!block.blockId) {
-                block.blockId = uuid();
-            }
-            if (block.elements) {
-                block.elements.forEach((element) => {
-                    if (!element.actionId) {
-                        element.actionId = uuid();
-                    }
-                });
-            }
-        });
-
-       return blocks;
-    }
 }

--- a/src/server/accessors/UIController.ts
+++ b/src/server/accessors/UIController.ts
@@ -1,12 +1,11 @@
-import { Block } from '@rocket.chat/ui-kit';
-import { v4 as uuid } from 'uuid';
 import { IUIController } from '../../definition/accessors';
 import { IUIKitErrorInteractionParam, IUIKitInteractionParam, IUIKitSurfaceViewParam } from '../../definition/accessors/IUIController';
-import { IBlock, UIKitInteractionType, UIKitSurfaceType } from '../../definition/uikit';
+import { UIKitInteractionType, UIKitSurfaceType } from '../../definition/uikit';
 import { formatContextualBarInteraction, formatErrorInteraction, formatModalInteraction } from '../../definition/uikit/UIKitInteractionPayloadFormatter';
 import { IUIKitContextualBarViewParam, IUIKitModalViewParam } from '../../definition/uikit/UIKitInteractionResponder';
 import { IUser } from '../../definition/users';
 import { AppBridges, UiInteractionBridge } from '../bridges';
+import { UIHelper } from '../misc/UIHelper';
 
 export class UIController implements IUIController {
     private readonly uiInteractionBridge: UiInteractionBridge;
@@ -46,7 +45,9 @@ export class UIController implements IUIController {
     }
 
     public openSurfaceView(view: IUIKitSurfaceViewParam, context: IUIKitInteractionParam, user: IUser) {
-        const viewWithIds = this.assignIds(view);
+        const blocks = UIHelper.assignIds(view.blocks, this.appId);
+        const viewWithIds = {...view, blocks};
+
         switch (view.type) {
             case UIKitSurfaceType.CONTEXTUAL_BAR:
                 return this.openContextualBar(viewWithIds, context, user);
@@ -56,7 +57,9 @@ export class UIController implements IUIController {
     }
 
     public updateSurfaceView(view: IUIKitSurfaceViewParam, context: IUIKitInteractionParam, user: IUser) {
-        const viewWithIds = this.assignIds(view);
+        const blocks = UIHelper.assignIds(view.blocks, this.appId);
+        const viewWithIds = {...view, blocks};
+
         switch (view.type) {
             case UIKitSurfaceType.CONTEXTUAL_BAR:
                 return this.openContextualBar(viewWithIds, context, user, true);
@@ -102,23 +105,4 @@ export class UIController implements IUIController {
         return this.uiInteractionBridge.doNotifyUser(user, formatModalInteraction(view, interactionContext), this.appId);
     }
 
-    private assignIds(view: IUIKitSurfaceViewParam): IUIKitSurfaceViewParam {
-        view.blocks.forEach((block: (IBlock | Block) & { appId?: string, blockId?: string, elements?: Array<any> }) => {
-            if (!block.appId) {
-                block.appId = this.appId;
-            }
-            if (!block.blockId) {
-                block.blockId = uuid();
-            }
-            if (block.elements) {
-                block.elements.forEach((element) => {
-                    if (!element.actionId) {
-                        element.actionId = uuid();
-                    }
-                });
-            }
-        });
-
-        return view;
-    }
 }

--- a/src/server/misc/UIHelper.ts
+++ b/src/server/misc/UIHelper.ts
@@ -1,0 +1,32 @@
+import { Block } from '@rocket.chat/ui-kit';
+import { v4 as uuid } from 'uuid';
+import { IBlock } from '../../definition/uikit';
+
+export class UIHelper {
+
+    /**
+     * Assign blockId, appId and actionId to every block/element inside the array
+     * @param blocks the blocks that will be iterated and assigned the ids
+     * @param appId the appId that will be assigned to
+     * @returns the array of block with the ids properties assigned
+     */
+    public static assignIds(blocks: Array<IBlock | Block>, appId: string): Array<IBlock | Block> {
+        blocks.forEach((block: (IBlock | Block) & { appId?: string, blockId?: string, elements?: Array<any> }) => {
+             if (!block.appId) {
+                 block.appId = appId;
+             }
+             if (!block.blockId) {
+                 block.blockId = uuid();
+             }
+             if (block.elements) {
+                 block.elements.forEach((element) => {
+                     if (!element.actionId) {
+                         element.actionId = uuid();
+                     }
+                 });
+             }
+         });
+
+        return blocks;
+     }
+}


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Assign blockId, appId, and actionId for the blocks and elements when calling openSurfaceView/updateSurfaceView method and on finish message builder.

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
[Task AE-55](https://rocketchat.atlassian.net/jira/software/c/projects/AE/boards/28?modal=detail&selectedIssue=AE-55)

# PS :eyes:
