### PR TITLE
[New] Support for x-www-form-urlencoded Body Params in OAuth2 calls

### DIFF
--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -76,16 +76,6 @@ export class OAuth2Client implements IOAuth2Client {
                 packageValue: '',
                 i18nLabel: `${this.config.alias}-oauth-client-secret`,
             }),
-
-            configuration.settings.provideSetting({
-                id: `${this.config.alias}-request-content-type`,
-                type: SettingType.STRING,
-                public: true,
-                required: false,
-                packageValue: '',
-                values: [{key:"0", i18nLabel:"No"},{key:"1", i18nLabel:"Yes"}],
-                i18nLabel: `Does your API requests require x-www-form-urlencoded content type?`,
-            }),
         ]);
     }
 
@@ -186,7 +176,20 @@ export class OAuth2Client implements IOAuth2Client {
             url.searchParams.set('refresh_token', tokenInfo.refreshToken);
             url.searchParams.set('grant_type', GrantType.RefreshToken);
 
-            const { content, statusCode } = await this.app.getAccessors().http.post(url.href);
+            let body = `client_id=${clientId}`;
+            body += `&scope=${this.config.defaultScopes.join(' ')}`;
+            body += `&refresh_token=${tokenInfo.refreshToken}`;
+            body += `&redirect_uri=${redirectUri}`;
+            body += `&grant_type=${GrantType.RefreshToken}`;
+            body += `&client_secret=${clientSecret}`;
+            body = encodeURI(body);
+
+            const { content, statusCode } = await this.app.getAccessors().http.post(url.href,{
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                content: body
+            });
 
             if (statusCode !== 200) {
                 throw new Error('Request to provider was unsuccessful. Check logs for more information');
@@ -228,7 +231,15 @@ export class OAuth2Client implements IOAuth2Client {
 
             url.searchParams.set('token', tokenInfo?.token);
 
-            const result = await this.app.getAccessors().http.post(url.href);
+            let body = `token=${tokenInfo.token}`;
+            body = encodeURI(body);
+
+            const result = await this.app.getAccessors().http.post(url.href,{
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                content: body
+            });
 
             if (result.statusCode !== 200) {
                 throw new Error('Provider did not allow token to be revoked');
@@ -317,12 +328,6 @@ export class OAuth2Client implements IOAuth2Client {
                 .getValueById(`${this.config.alias}-oauth-clientsecret`);
 
             const url = new URL(accessTokenUrl, siteUrl);
-            
-            const content_type = await this.app
-            .getAccessors()
-            .reader.getEnvironmentReader()
-            .getSettings()
-            .getValueById(`${this.config.alias}-request-content-type`);
 
             url.searchParams.set('client_id', clientId);
             url.searchParams.set('redirect_uri', `${siteUrl}/${redirectUri}`);
@@ -335,7 +340,7 @@ export class OAuth2Client implements IOAuth2Client {
             body += `&scope=${this.config.defaultScopes.join(' ')}`;
             body += `&code=${code}`;
             body += `&redirect_uri=${redirectUri}`;
-            body += `&grant_type=authorization_code`;
+            body += `&grant_type=${GrantType.AuthorizationCode}`;
             body += `&client_secret=${clientSecret}`;
             body = encodeURI(body);
     

--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -30,8 +30,8 @@ export class OAuth2Client implements IOAuth2Client {
     private defaultContents = {
         success:  '<div style="display: flex;align-items: center;justify-content: center; height: 100%;">\
                         <h1 style="text-align: center; font-family: Helvetica Neue;">\
-                            Authorization successful.<br>\
-                            You may now close this tab.<br>\
+                            Authorization went successfully<br>\
+                            You can now close this tab now<br>\
                         </h1>\
                     </div>',
         failed: '<div style="display: flex;align-items: center;justify-content: center; height: 100%;">\

--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -31,7 +31,7 @@ export class OAuth2Client implements IOAuth2Client {
         success:  '<div style="display: flex;align-items: center;justify-content: center; height: 100%;">\
                         <h1 style="text-align: center; font-family: Helvetica Neue;">\
                             Authorization went successfully<br>\
-                            You can now close this tab now<br>\
+                            You can close this tab now<br>\
                         </h1>\
                     </div>',
         failed: '<div style="display: flex;align-items: center;justify-content: center; height: 100%;">\

--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -417,7 +417,6 @@ export class OAuth2Client implements IOAuth2Client {
             true, // we want to create the record if it doesn't exist
         );
     }
-
     private async removeToken({
         userId,
         persis,

--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -184,11 +184,11 @@ export class OAuth2Client implements IOAuth2Client {
             body += `&client_secret=${clientSecret}`;
             body = encodeURI(body);
 
-            const { content, statusCode } = await this.app.getAccessors().http.post(url.href,{
+            const { content, statusCode } = await this.app.getAccessors().http.post(url.href, {
                 headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
+                    'Content-Type': 'application/x-www-form-urlencoded',
                 },
-                content: body
+                content: body,
             });
 
             if (statusCode !== 200) {
@@ -234,11 +234,11 @@ export class OAuth2Client implements IOAuth2Client {
             let body = `token=${tokenInfo.token}`;
             body = encodeURI(body);
 
-            const result = await this.app.getAccessors().http.post(url.href,{
+            const result = await this.app.getAccessors().http.post(url.href, {
                 headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
+                    'Content-Type': 'application/x-www-form-urlencoded',
                 },
-                content: body
+                content: body,
             });
 
             if (result.statusCode !== 200) {
@@ -343,13 +343,12 @@ export class OAuth2Client implements IOAuth2Client {
             body += `&grant_type=${GrantType.AuthorizationCode}`;
             body += `&client_secret=${clientSecret}`;
             body = encodeURI(body);
-    
 
             const { content, statusCode } = await http.post(url.href, {
-                headers: { Accept: 'application/json',
-                 'Content-Type': 'application/x-www-form-urlencoded'
+                headers: { 'Accept': 'application/json',
+                 'Content-Type': 'application/x-www-form-urlencoded',
             },
-                content: body
+                content: body,
             });
 
             // If provider had a server error, nothing we can do


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

- Added support for OAuth2 Clients that require parameters in Body as x-www-form-urlencoded Content-Type.
- Backwards compatible, does not affect client that don't require parameters in Body.

# Why? :thinking:
<!--Additional explanation if needed-->
We need this in using Microsoft Graph API and other OAuth2 Clients.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
