### PR TITLE
[NEW] Add "password" setting type

### DIFF
--- a/docs/enums/settings_settingtype.settingtype.html
+++ b/docs/enums/settings_settingtype.settingtype.html
@@ -83,6 +83,7 @@
 								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="settings_settingtype.settingtype.html#number" class="tsd-kind-icon">NUMBER</a></li>
 								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="settings_settingtype.settingtype.html#select" class="tsd-kind-icon">SELECT</a></li>
 								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="settings_settingtype.settingtype.html#string" class="tsd-kind-icon">STRING</a></li>
+								<li class="tsd-kind-enum-member tsd-parent-kind-enum"><a href="settings_settingtype.settingtype.html#password" class="tsd-kind-icon">PASSWORD</a></li>
 							</ul>
 						</section>
 					</div>
@@ -170,6 +171,16 @@
 						</ul>
 					</aside>
 				</section>
+				<section class="tsd-panel tsd-member tsd-kind-enum-member tsd-parent-kind-enum">
+					<a name="string" class="tsd-anchor"></a>
+					<h3>PASSWORD</h3>
+					<div class="tsd-signature tsd-kind-icon">PASSWORD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;password&quot;</span></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/RocketChat/Rocket.Chat.Apps-engine/blob/2105fdd/src/definition/settings/SettingType.ts#L10">src/definition/settings/SettingType.ts:10</a></li>
+						</ul>
+					</aside>
+				</section>
 			</section>
 		</div>
 		<div class="col-4 col-menu menu-sticky-wrap menu-highlight">
@@ -213,6 +224,9 @@
 							</li>
 							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
 								<a href="settings_settingtype.settingtype.html#string" class="tsd-kind-icon">STRING</a>
+							</li>
+							<li class=" tsd-kind-enum-member tsd-parent-kind-enum">
+								<a href="settings_settingtype.settingtype.html#password" class="tsd-kind-icon">PASSWORD</a>
 							</li>
 						</ul>
 					</li>

--- a/src/definition/settings/SettingType.ts
+++ b/src/definition/settings/SettingType.ts
@@ -7,5 +7,7 @@ export enum SettingType {
     SELECT = 'select',
     STRING = 'string',
     MULTI_SELECT = 'multiSelect',
+	// Renders an input of type 'password' in the form. IMPORTANT - the value will NOT be encrypted
+	// it will be treated as a password just on the screen
     PASSWORD = 'password',
 }

--- a/src/definition/settings/SettingType.ts
+++ b/src/definition/settings/SettingType.ts
@@ -7,4 +7,5 @@ export enum SettingType {
     SELECT = 'select',
     STRING = 'string',
     MULTI_SELECT = 'multiSelect',
+    PASSWORD = 'password',
 }

--- a/src/definition/settings/SettingType.ts
+++ b/src/definition/settings/SettingType.ts
@@ -7,7 +7,7 @@ export enum SettingType {
     SELECT = 'select',
     STRING = 'string',
     MULTI_SELECT = 'multiSelect',
-	// Renders an input of type 'password' in the form. IMPORTANT - the value will NOT be encrypted
-	// it will be treated as a password just on the screen
+    // Renders an input of type 'password' in the form. IMPORTANT - the value will NOT be encrypted
+    // it will be treated as a password just on the screen
     PASSWORD = 'password',
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Adds "Password" to the list of allowed setting types

# Why? :thinking:
So apps can create password settings.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
