### PR TITLE
Fixed Masked SettingType

### DIFF
--- a/src/definition/settings/SettingType.ts
+++ b/src/definition/settings/SettingType.ts
@@ -7,4 +7,5 @@ export enum SettingType {
     SELECT = 'select',
     STRING = 'string',
     MULTI_SELECT = 'multiSelect',
+    PASSWORD = 'password',
 }

--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -61,7 +61,7 @@ export class OAuth2Client implements IOAuth2Client {
         await Promise.all([
             configuration.settings.provideSetting({
                 id: `${this.config.alias}-oauth-client-id`,
-                type: SettingType.STRING,
+                type: SettingType.PASSWORD,
                 public: true,
                 required: true,
                 packageValue: '',
@@ -70,7 +70,7 @@ export class OAuth2Client implements IOAuth2Client {
 
             configuration.settings.provideSetting({
                 id: `${this.config.alias}-oauth-clientsecret`,
-                type: SettingType.STRING,
+                type: SettingType.PASSWORD,
                 public: true,
                 required: true,
                 packageValue: '',


### PR DESCRIPTION
This closes https://github.com/RocketChat/Rocket.Chat.Apps-engine/issues/238

The fix/hack I've added is to append a PASSWORD attribute to the SettingType enum and used it in the provideSetting configuration. 