### PR TITLE
Regression: Enable app individual loading routine

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -783,13 +783,14 @@ export class AppManager {
      * @param appId the id of the application to load
      */
     public async loadOne(appId: string): Promise<ProxiedApp> {
-        const item: IAppStorageItem = await this.appMetadataStorage.retrieveOne(appId);
+        const rl = this.apps.get(appId);
 
-        if (!item) {
+        if (!rl) {
             throw new Error(`No App found by the id of: "${ appId }"`);
         }
 
-        const rl = this.apps.get(item.id);
+        const item = rl.getStorageItem();
+
         await this.initializeApp(item, rl, false);
 
         if (!this.areRequiredSettingsSet(item)) {

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -782,20 +782,12 @@ export class AppManager {
      *
      * @param appId the id of the application to load
      */
-    protected async loadOne(appId: string): Promise<ProxiedApp> {
-        if (this.apps.get(appId)) {
-            return this.apps.get(appId);
-        }
-
+    public async loadOne(appId: string): Promise<ProxiedApp> {
         const item: IAppStorageItem = await this.appMetadataStorage.retrieveOne(appId);
-        const appPackage = await this.appSourceStorage.fetch(item);
-        const unpackageResult = await this.getParser().unpackageApp(appPackage);
 
         if (!item) {
             throw new Error(`No App found by the id of: "${ appId }"`);
         }
-
-        this.apps.set(item.id, this.getCompiler().toSandBox(this, item, unpackageResult));
 
         const rl = this.apps.get(item.id);
         await this.initializeApp(item, rl, false);


### PR DESCRIPTION
# What? :boat:
Check the app's status not to enable it if it was manually disabled.
<!--
- Added x;
- Updated y;
- Removed z.
-->

# Why? :thinking:
Every app was enabled at the server's startup, even the ones the user disabled. With the fix, the ones that were disabled manually by the user keep their statuses.
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
Related to [PR](https://github.com/RocketChat/Rocket.Chat/pull/28322)
[AE-109](https://rocketchat.atlassian.net/browse/AE-109)


[AE-109]: https://rocketchat.atlassian.net/browse/AE-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ