### PR TITLE
fix: Create and delete bot user

### DIFF
--- a/src/definition/accessors/IModifyDeleter.ts
+++ b/src/definition/accessors/IModifyDeleter.ts
@@ -1,7 +1,8 @@
+import { UserType } from './../users/UserType';
 import type { IUser } from '../users';
 
 export interface IModifyDeleter {
     deleteRoom(roomId: string): Promise<void>;
 
-    deleteBotUsers(appId: Exclude<IUser['appId'], undefined>): Promise<boolean>;
+    deleteUsers(appId: Exclude<IUser['appId'], undefined>, userType: UserType.APP | UserType.BOT): Promise<boolean>;
 }

--- a/src/definition/accessors/IModifyDeleter.ts
+++ b/src/definition/accessors/IModifyDeleter.ts
@@ -1,5 +1,4 @@
-import { UserType } from './../users/UserType';
-import type { IUser } from '../users';
+import type { IUser, UserType } from '../users';
 
 export interface IModifyDeleter {
     deleteRoom(roomId: string): Promise<void>;

--- a/src/definition/users/IBotUser.ts
+++ b/src/definition/users/IBotUser.ts
@@ -2,5 +2,5 @@ import { IUser } from './IUser';
 import { UserType } from './UserType';
 
 export interface IBotUser extends Omit<IUser, 'emails'> {
-    type: UserType.BOT;
+    type: UserType.BOT | UserType.APP;
 }

--- a/src/server/accessors/ModifyCreator.ts
+++ b/src/server/accessors/ModifyCreator.ts
@@ -92,8 +92,9 @@ export class ModifyCreator implements IModifyCreator {
         if (data) {
             delete data.id;
 
-            if (data.roles && data.roles.length) {
-                const roles = data.roles;
+            const roles = data.roles;
+
+            if (roles && roles.length) {
                 const hasRole = roles.map((role) => role.toLocaleLowerCase()).some((role) => role === 'admin' || role === 'owner' || role === 'moderator');
 
                 if (hasRole) {

--- a/src/server/accessors/ModifyDeleter.ts
+++ b/src/server/accessors/ModifyDeleter.ts
@@ -9,7 +9,7 @@ export class ModifyDeleter implements IModifyDeleter {
         return this.bridges.getRoomBridge().doDelete(roomId, this.appId);
     }
 
-    public async deleteBotUsers(appId: Exclude<IUser['appId'], undefined>): Promise<boolean> {
-        return this.bridges.getUserBridge().doDeleteUsersCreatedByApp(appId, UserType.BOT);
+    public async deleteUsers(appId: Exclude<IUser['appId'], undefined>, userType: UserType.APP | UserType.BOT): Promise<boolean> {
+        return this.bridges.getUserBridge().doDeleteUsersCreatedByApp(appId, userType);
     }
 }

--- a/src/server/bridges/UserBridge.ts
+++ b/src/server/bridges/UserBridge.ts
@@ -45,7 +45,7 @@ export abstract class UserBridge extends BaseBridge {
         }
     }
 
-    public async doDeleteUsersCreatedByApp(appId: string, type: UserType.BOT): Promise<boolean> {
+    public async doDeleteUsersCreatedByApp(appId: string, type: UserType.BOT | UserType.APP): Promise<boolean> {
         if (this.hasWritePermission(appId)) {
             return this.deleteUsersCreatedByApp(appId, type);
         }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
The first proposal assumed that the bot doesn't consume billable seats. But, that isn't true, it consumes.

# Why? :thinking:
<!--Additional explanation if needed-->
Before, the app created and deleted just bot users and now we changes some parameters to allow the app to create and delete bot and app users.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:

AECO-62
