### PR TITLE
[FIX] Fix event broadcast to happen after the app has been removed

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -234,7 +234,7 @@ export class AppManager {
                 const appPackage = await this.appSourceStorage.fetch(item);
                 const unpackageResult = await this.getParser().unpackageApp(appPackage);
 
-                const app = this.getCompiler().toSandBox(this, item, unpackageResult);
+                const app = await this.getCompiler().toSandBox(this, item, unpackageResult);
 
                 this.apps.set(item.id, app);
             } catch (e) {
@@ -243,7 +243,7 @@ export class AppManager {
 
                 const app = DisabledApp.createNew(item.info, AppStatus.COMPILER_ERROR_DISABLED);
                 app.getLogger().error(e);
-                this.logStorage.storeEntries(app.getID(), app.getLogger());
+                await this.logStorage.storeEntries(app.getID(), app.getLogger());
 
                 const prl = new ProxiedApp(this, item, app, new AppsEngineEmptyRuntime(app));
                 this.apps.set(item.id, prl);
@@ -487,7 +487,7 @@ export class AppManager {
 
         // Now that is has all been compiled, let's get the
         // the App instance from the source.
-        const app = this.getCompiler().toSandBox(this, descriptor, result);
+        const app = await this.getCompiler().toSandBox(this, descriptor, result);
 
         // Create a user for the app
         try {
@@ -547,7 +547,7 @@ export class AppManager {
         const app = this.apps.get(id);
         const { user } = uninstallationParameters;
 
-        // First
+        // First remove the app
         await this.uninstallApp(app, user);
         await this.removeLocal(id);
 
@@ -620,7 +620,7 @@ export class AppManager {
         descriptor.signature = await this.signatureManager.signApp(descriptor);
         const stored = await this.appMetadataStorage.update(descriptor);
 
-        const app = this.getCompiler().toSandBox(this, descriptor, result);
+        const app = await this.getCompiler().toSandBox(this, descriptor, result);
 
         // Ensure there is an user for the app
         try {

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -554,7 +554,6 @@ export class AppManager {
         // Then let everyone know that the App has been removed
         await this.bridges.getAppActivationBridge().doAppRemoved(app).catch();
 
-
         return app;
     }
 

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -547,12 +547,13 @@ export class AppManager {
         const app = this.apps.get(id);
         const { user } = uninstallationParameters;
 
+        // First
         await this.uninstallApp(app, user);
+        await this.removeLocal(id);
 
-        // Let everyone know that the App has been removed
+        // Then let everyone know that the App has been removed
         await this.bridges.getAppActivationBridge().doAppRemoved(app).catch();
 
-        await this.removeLocal(id);
 
         return app;
     }

--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -89,7 +89,7 @@ export class ProxiedApp implements IApp {
                 throw e;
             }
         } finally {
-            this.manager.getLogStorage().storeEntries(this.getID(), logger);
+            await this.manager.getLogStorage().storeEntries(this.getID(), logger);
         }
 
         return result;

--- a/src/server/compiler/AppCompiler.ts
+++ b/src/server/compiler/AppCompiler.ts
@@ -23,7 +23,7 @@ export class AppCompiler {
         return result;
     }
 
-    public toSandBox(manager: AppManager, storage: IAppStorageItem, { files }: IParseAppPackageResult): ProxiedApp {
+    public async toSandBox(manager: AppManager, storage: IAppStorageItem, { files }: IParseAppPackageResult): Promise<ProxiedApp> {
         if (typeof files[path.normalize(storage.info.classFile)] === 'undefined') {
             throw new Error(`Invalid App package for "${ storage.info.name }". ` +
                 `Could not find the classFile (${ storage.info.classFile }) file.`);
@@ -81,7 +81,7 @@ export class AppCompiler {
         // TODO: Fix this type cast from to any to the right one
         const app = new ProxiedApp(manager, storage, rl as App, new Runtime(rl as App, customRequire as any));
 
-        manager.getLogStorage().storeEntries(app.getID(), logger);
+        await manager.getLogStorage().storeEntries(app.getID(), logger);
 
         return app;
     }

--- a/src/server/managers/AppApi.ts
+++ b/src/server/managers/AppApi.ts
@@ -92,12 +92,12 @@ export class AppApi {
                 ],
             });
             logger.debug(`${ path }'s ${ method } was successfully executed.`);
-            logStorage.storeEntries(this.app.getID(), logger);
+            await logStorage.storeEntries(this.app.getID(), logger);
             return result;
         } catch (e) {
             logger.error(e);
             logger.debug(`${ path }'s ${ method } was unsuccessful.`);
-            logStorage.storeEntries(this.app.getID(), logger);
+            await logStorage.storeEntries(this.app.getID(), logger);
             throw e;
         }
     }

--- a/src/server/managers/AppSlashCommandManager.ts
+++ b/src/server/managers/AppSlashCommandManager.ts
@@ -285,6 +285,9 @@ export class AppSlashCommandManager {
                 const cmd = appSlashCommand.slashCommand.command;
                 await this.bridge.doUnregisterCommand(cmd, appId);
                 this.touchedCommandsToApps.delete(cmd);
+                if (!this.appsTouchedCommands.has(appId)) {
+                    continue;
+                }
                 const ind = this.appsTouchedCommands.get(appId).indexOf(cmd);
                 this.appsTouchedCommands.get(appId).splice(ind, 1);
                 appSlashCommand.isRegistered = true;


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
- Makes event broadcast to happen _after_ the app has been removed, not before

# Why? :thinking:
<!--Additional explanation if needed-->
- Fixes a race condition between multiple calls to `manager.remove` or `manager.removeLocal` that causes apps to not be able to be uninstalled
- Validates `this.appTouchedCommands` has data before accessing it
- Add awaits to support LogStorage to be async now
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
