### PR TITLE
Add Room Pick Setting

### DIFF
--- a/src/definition/settings/ISetting.ts
+++ b/src/definition/settings/ISetting.ts
@@ -9,8 +9,10 @@ export interface ISetting {
     packageValue: any;
     /** Will be the value of this setting. If nothing is set here, then the "packageValue" will be used. */
     /**
-     * If the setting type is ROOM_PICK, then the value will be an array of room ids.
-     * e.g. [ { _id: 'GENERAL' }, { _id: 'cFhgqGnZAY5dq85Z4' }
+     * If the setting type is ROOM_PICK, the value will be an array of room ids.
+     * @returns ```js
+     * [{_id: 'rid1'}, {_id: 'rid2'}]
+     * ```
      */
     value?: any;
     /** Whether this setting is required or not. */

--- a/src/definition/settings/ISetting.ts
+++ b/src/definition/settings/ISetting.ts
@@ -8,6 +8,10 @@ export interface ISetting {
     /** What is the default value (allows a reset button). */
     packageValue: any;
     /** Will be the value of this setting. If nothing is set here, then the "packageValue" will be used. */
+    /**
+     * If the setting type is ROOM_PICK, then the value will be an array of room ids.
+     * e.g. [ { _id: 'GENERAL' }, { _id: 'cFhgqGnZAY5dq85Z4' }
+     */
     value?: any;
     /** Whether this setting is required or not. */
     required: boolean;

--- a/src/definition/settings/SettingType.ts
+++ b/src/definition/settings/SettingType.ts
@@ -10,4 +10,5 @@ export enum SettingType {
     // Renders an input of type 'password' in the form. IMPORTANT - the value will NOT be encrypted
     // it will be treated as a password just on the screen
     PASSWORD = 'password',
+    ROOM_PICK = 'roomPick',
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
- Added the room pick setting type
# Why? :thinking:
<!--Additional explanation if needed-->
Many apps require adding a room name in settings for specific use purposes; currently, the developer could allow admins to enter room names as a string; however, after this feature release, adding rooms will be pretty convenient as a simple click-n-select.
Setting preview:
![image](https://user-images.githubusercontent.com/61188295/236830714-606192ce-7225-4730-a852-71bc64d60674.png)

The room setting value after selecting the rooms will be:
```jsx
value: [ { _id: 'GENERAL' }, { _id: 'cFhgqGnZAY5dq85Z4' } ]
```
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
The `roomPick` setting is already implemented in the core. I have also tried to improve the comments for the value, haha, since many times, I had to console log to view the `value` structure after a change in settings. Thank you!