### PR TITLE
[FIX] loadOne doesn't fetch app data from database

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -471,7 +471,7 @@ export class AppManager {
 
         this.apps.set(app.getID(), app);
 
-        await this.loadOne(appId)
+        await this.loadOne(appId);
     }
 
     public async add(appPackage: Buffer, installationParameters: IAppInstallParameters): Promise<AppFabricationFulfillment> {

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -453,6 +453,25 @@ export class AppManager {
         return true;
     }
 
+    public async addLocal(appId: string): Promise<void> {
+        const storageItem = await this.appMetadataStorage.retrieveOne(appId);
+
+        if (!storageItem) {
+            throw new Error(`App with id ${appId} couldn't be found`);
+        }
+
+        const appPackage = await this.appSourceStorage.fetch(storageItem);
+
+        if (!appPackage) {
+            throw new Error(`Package file for app "${storageItem.info.name}" (${appId}) couldn't be found`);
+        }
+
+        const parsedPackage = await this.getParser().unpackageApp(appPackage);
+        const app = await this.getCompiler().toSandBox(this, storageItem, parsedPackage);
+
+        this.apps.set(app.getID(), app);
+    }
+
     public async add(appPackage: Buffer, installationParameters: IAppInstallParameters): Promise<AppFabricationFulfillment> {
         const { enable = true, marketplaceInfo, permissionsGranted, user } = installationParameters;
 

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -470,6 +470,8 @@ export class AppManager {
         const app = await this.getCompiler().toSandBox(this, storageItem, parsedPackage);
 
         this.apps.set(app.getID(), app);
+
+        await this.loadOne(appId)
     }
 
     public async add(appPackage: Buffer, installationParameters: IAppInstallParameters): Promise<AppFabricationFulfillment> {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Added a new method `addLocal` which is the correspondent version of `add`  that will load an app from the database and start it up.
# Why? :thinking:
<!--Additional explanation if needed-->
Previously the `loadOne` method was used to load apps when an instance of Rocket.Chat received a notification that an app had been installed somewhere else in the cluster. However, due to changes to this method, it was actually breaking this flow. The new method is added to provide the lost functionality
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
Rocket.Chat PR with implementation: https://github.com/RocketChat/Rocket.Chat/pull/29180
