### PR TITLE
regression: UIKit changes broke compatibility

### DIFF
--- a/src/definition/uikit/UIKitIncomingInteractionTypes.ts
+++ b/src/definition/uikit/UIKitIncomingInteractionTypes.ts
@@ -37,23 +37,20 @@ export interface IUIKitViewCloseIncomingInteraction extends IUIKitBaseIncomingIn
     isCleared: boolean;
 }
 
-/** @deprecated */
 export interface IUIKitActionButtonIncomingInteraction extends IUIKitBaseIncomingInteraction {
-    buttonContext: Exclude<`${UIActionButtonContext}`, 'messageBoxAction'>;
+    buttonContext: UIActionButtonContext;
     actionId: string;
     triggerId: string;
     room: IRoom;
     message?: IMessage;
 }
 
-export interface IUIKitActionButtonMessageBoxIncomingInteraction extends IUIKitBaseIncomingInteraction {
-    buttonContext: `messageBoxAction`;
-    actionId: string;
-    triggerId: string;
-    room: IRoom;
-    message?: string;
-
+export interface IUIKitActionButtonMessageBoxIncomingInteraction extends IUIKitActionButtonIncomingInteraction {
+    buttonContext: UIActionButtonContext.MESSAGE_BOX_ACTION;
+    text?: string;
     threadId?: string;
 }
 
-export type UIKitActionButtonIncomingInteraction = IUIKitActionButtonIncomingInteraction | IUIKitActionButtonMessageBoxIncomingInteraction;
+export function isMessageBoxIncomingInteraction(interaction: IUIKitActionButtonIncomingInteraction): interaction is IUIKitActionButtonMessageBoxIncomingInteraction {
+    return interaction.buttonContext === UIActionButtonContext.MESSAGE_BOX_ACTION;
+}

--- a/src/definition/uikit/UIKitInteractionContext.ts
+++ b/src/definition/uikit/UIKitInteractionContext.ts
@@ -1,10 +1,11 @@
 // tslint:disable:max-classes-per-file
 import {
+    IUIKitActionButtonIncomingInteraction,
+    IUIKitActionButtonMessageBoxIncomingInteraction,
     IUIKitBaseIncomingInteraction,
     IUIKitBlockIncomingInteraction,
     IUIKitViewCloseIncomingInteraction,
     IUIKitViewSubmitIncomingInteraction,
-    UIKitActionButtonIncomingInteraction,
 } from './UIKitIncomingInteractionTypes';
 import { UIKitInteractionResponder } from './UIKitInteractionResponder';
 
@@ -57,11 +58,11 @@ export class UIKitViewCloseInteractionContext extends UIKitInteractionContext {
 }
 
 export class UIKitActionButtonInteractionContext extends UIKitInteractionContext {
-    constructor(private readonly interactionData: UIKitActionButtonIncomingInteraction) {
+    constructor(private readonly interactionData: IUIKitActionButtonIncomingInteraction | IUIKitActionButtonMessageBoxIncomingInteraction) {
         super(interactionData);
     }
 
-    public getInteractionData(): UIKitActionButtonIncomingInteraction {
+    public getInteractionData(): IUIKitActionButtonIncomingInteraction {
         return this.interactionData;
     }
 }

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -13,6 +13,7 @@ import {
 } from '../../definition/messages';
 import { AppInterface, AppMethod } from '../../definition/metadata';
 import { IRoom, IRoomUserJoinedContext, IRoomUserLeaveContext, RoomType } from '../../definition/rooms';
+import { UIActionButtonContext } from '../../definition/ui';
 import { IUIKitResponse, IUIKitSurface, UIKitIncomingInteraction, UIKitIncomingInteractionType } from '../../definition/uikit';
 import { isUIKitIncomingInteractionActionButtonMessageBox } from '../../definition/uikit/IUIKitIncomingInteractionActionButton';
 import { IUIKitLivechatIncomingInteraction, UIKitLivechatBlockInteractionContext } from '../../definition/uikit/livechat';
@@ -1117,12 +1118,12 @@ export class AppListenerManager {
                         new UIKitActionButtonInteractionContext({
                             appId,
                             actionId,
-                            buttonContext: 'messageBoxAction',
+                            buttonContext: UIActionButtonContext.MESSAGE_BOX_ACTION,
                             room: data.room,
                             triggerId,
                             user,
                             threadId: data.tmid,
-                            ...('message' in data.payload && { message: data.payload.message }),
+                            ...('message' in data.payload && { text: data.payload.message }),
                         }),
                         this.am.getReader(appId),
                         this.am.getHttp(appId),
@@ -1137,7 +1138,7 @@ export class AppListenerManager {
                         appId,
                         actionId,
                         triggerId,
-                        buttonContext: data.payload.context,
+                        buttonContext: data.payload.context as UIActionButtonContext,
                         room: ('room' in data && data.room) || undefined,
                         user,
                         ...('message' in data && { message: data.message }),


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Some recent UIKit changes broke API compatibility, this PR fixes the situation.
# Why? :thinking:
<!--Additional explanation if needed-->
Breaking changes in the public API should only happen on major bumps.
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
