### PR TITLE
feat: adding isEnterpriseOnly flag

### DIFF
--- a/src/server/marketplace/IMarketplaceInfo.ts
+++ b/src/server/marketplace/IMarketplaceInfo.ts
@@ -20,4 +20,5 @@ export interface IMarketplaceInfo extends IAppInfo {
     purchaseType: MarketplacePurchaseType;
     pricingPlans?: Array<IMarketplacePricingPlan>;
     bundledIn?: Array<IMarketplaceSimpleBundleInfo>;
+    isEnterpriseOnly?: boolean;
 }


### PR DESCRIPTION
# What? :boat:

Adding the `isEnterpriseOnly` flag in the marketplace info
<!--
- Added x;
- Updated y;
- Removed z.
-->

# Why? :thinking:

This flag will be used in the Rocket.chat to determine whether is possible to enable an app or not
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
