### PR TITLE
new: add rep roles bridge

### DIFF
--- a/src/definition/accessors/IModerationModify.ts
+++ b/src/definition/accessors/IModerationModify.ts
@@ -24,4 +24,19 @@ export interface IModerationModify {
      * @param appId the app id
      */
     dismissReportsByUserId(userId: IUser['id'], reason: string, action: string, appId: string): Promise<void>;
+
+    /**
+     * Provides a way for Apps to add rep roles.
+     * @param appId the app id
+     * @throws if the app does not have the permission to add rep roles
+     */
+    addRepRoles(appId: string): Promise<void>;
+
+    /**
+     * Provides a way for Apps to add default permissions to rep roles.
+     * @param appId the app id
+     * @throws if the app does not have the permission to add rep roles
+     * @throws if the app does not have the permission to add default permissions to rep roles
+     */
+    addRepRolePermissions(appId: string): Promise<void>;
 }

--- a/src/definition/package.json
+++ b/src/definition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-ts-definition",
-  "version": "1.40.0-alpha",
+  "version": "1.41.0-alpha",
   "description": "Contains the TypeScript definitions for the Rocket.Chat Applications.",
   "main": "index.js",
   "typings": "index",

--- a/src/server/accessors/ModerationModify.ts
+++ b/src/server/accessors/ModerationModify.ts
@@ -17,4 +17,12 @@ export class ModerationModify implements IModerationModify {
     public dismissReportsByUserId(userId: IUser['id'], reason: string, action: string, appId: string): Promise<void> {
         return this.moderationBridge.doDismissReportsByUserId(userId, reason, action, appId);
     }
+
+    public addRepRoles(appId: string): Promise<void> {
+        return this.moderationBridge.doAddRepRoles(appId);
+    }
+
+    public addRepRolePermissions(appId: string): Promise<void> {
+        return this.moderationBridge.doAddRepRolePermissions(appId);
+    }
 }

--- a/src/server/bridges/ModerationBridge.ts
+++ b/src/server/bridges/ModerationBridge.ts
@@ -24,9 +24,23 @@ export abstract class ModerationBridge extends BaseBridge {
         }
     }
 
+    public async doAddRepRoles(appId: string): Promise<void> {
+        if (this.hasWritePermission(appId)) {
+            return this.addRepRoles(appId);
+        }
+    }
+
+    public async doAddRepRolePermissions(appId: string): Promise<void> {
+        if (this.hasWritePermission(appId)) {
+            return this.addRepRolePermissions(appId);
+        }
+    }
+
     protected abstract report(messageId: string, description: string, userId: string, appId: string): Promise<void>;
     protected abstract dismissReportsByMessageId(messageId: string, reason: string, action: string, appId: string): Promise<void>;
     protected abstract dismissReportsByUserId(userId: string, reason: string, action: string, appId: string): Promise<void>;
+    protected abstract addRepRoles(appId: string): Promise<void>;
+    protected abstract addRepRolePermissions(appId: string): Promise<void>;
 
     private hasWritePermission(appId: string): boolean {
         if (AppPermissionManager.hasPermission(appId, AppPermissions.moderation.write)) {

--- a/tests/test-data/bridges/moderationBridge.ts
+++ b/tests/test-data/bridges/moderationBridge.ts
@@ -14,4 +14,12 @@ export class TestsModerationBridge extends ModerationBridge {
     public dismissReportsByUserId(userId: IUser['id'], reason: string, action: string, appId: string): Promise<void> {
         throw new Error('Method not implemented.');
     }
+
+    public addRepRoles(appId: string): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    public addRepRolePermissions(appId: string): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

- Added two new moderation bridge methods

# Why? :thinking:
<!--Additional explanation if needed-->

To handle adding two new reputation roles from inside the Reputation App. And two methods because one is for creating roles, while the other is for adding some default permissions to the roles. This allowed for better error handling.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

[WM-74](https://rocketchat.atlassian.net/browse/WM-74)

# PS :eyes:

More details are coming soon...as soon as this is RFR. Thank you!