### PR TITLE
chore: Revert "feat: Add toast message interaction (#657)"

### DIFF
--- a/src/definition/accessors/IUIController.ts
+++ b/src/definition/accessors/IUIController.ts
@@ -1,6 +1,5 @@
 import type { IUIKitErrorInteraction, IUIKitInteraction, IUIKitSurface } from '../uikit';
 import type { Omit } from '../../lib/utils';
-import type { IToastMessagePayload } from '../ui/IToastMessagePaylaod';
 import type { IUIKitContextualBarViewParam, IUIKitModalViewParam } from '../uikit/UIKitInteractionResponder';
 import type { IUser } from '../users';
 
@@ -29,5 +28,4 @@ export interface IUIController {
     setViewError(errorInteraction: IUIKitErrorInteractionParam, context: IUIKitInteractionParam, user: IUser): Promise<void>;
     openSurfaceView(view: IUIKitSurfaceViewParam, context: IUIKitInteractionParam, user: IUser): Promise<void>;
     updateSurfaceView(view: IUIKitSurfaceViewParam, context: IUIKitInteractionParam, user: IUser): Promise<void>;
-    dispatchToastMessage(toast: IToastMessagePayload, context: IUIKitInteractionParam, user: IUser): Promise<void>;
 }

--- a/src/definition/ui/IToastMessagePaylaod.ts
+++ b/src/definition/ui/IToastMessagePaylaod.ts
@@ -1,4 +1,0 @@
-export interface IToastMessagePayload {
-    type: 'success' | 'info' | 'warning' | 'error';
-    message: string;
-}

--- a/src/definition/uikit/IUIKitInteractionType.ts
+++ b/src/definition/uikit/IUIKitInteractionType.ts
@@ -1,4 +1,3 @@
-import type { IToastMessagePayload } from '../ui/IToastMessagePaylaod';
 import type { IUIKitSurface } from './IUIKitSurface';
 
 export enum UIKitInteractionType {
@@ -8,7 +7,6 @@ export enum UIKitInteractionType {
     CONTEXTUAL_BAR_OPEN = 'contextual_bar.open',
     CONTEXTUAL_BAR_CLOSE = 'contextual_bar.close',
     CONTEXTUAL_BAR_UPDATE = 'contextual_bar.update',
-    TOAST_MESSAGE = 'toast_message',
     ERRORS = 'errors',
 }
 
@@ -20,11 +18,6 @@ export interface IUIKitInteraction {
     type: UIKitInteractionType;
     triggerId: string;
     appId: string;
-}
-
-export interface IUIKitToastMessageInteraction extends IUIKitInteraction {
-    type: UIKitInteractionType.TOAST_MESSAGE;
-    toast: IToastMessagePayload;
 }
 
 export interface IUIKitErrorInteraction extends IUIKitInteraction {

--- a/src/definition/uikit/UIKitInteractionPayloadFormatter.ts
+++ b/src/definition/uikit/UIKitInteractionPayloadFormatter.ts
@@ -1,14 +1,7 @@
 import { v1 as uuid } from 'uuid';
 
 import type { IUIKitErrorInteractionParam } from '../accessors/IUIController';
-import type { IToastMessagePayload } from '../ui/IToastMessagePaylaod';
-import type {
-    IUIKitContextualBarInteraction,
-    IUIKitErrorInteraction,
-    IUIKitInteraction,
-    IUIKitModalInteraction,
-    IUIKitToastMessageInteraction,
-} from './IUIKitInteractionType';
+import type { IUIKitContextualBarInteraction, IUIKitErrorInteraction, IUIKitInteraction, IUIKitModalInteraction } from './IUIKitInteractionType';
 import { UIKitInteractionType } from './IUIKitInteractionType';
 import type { IUIKitSurface } from './IUIKitSurface';
 import { UIKitSurfaceType } from './IUIKitSurface';
@@ -71,18 +64,5 @@ export function formatErrorInteraction(errorInteraction: IUIKitErrorInteractionP
         errors: errorInteraction.errors,
         viewId: errorInteraction.viewId,
         triggerId: context.triggerId,
-    };
-}
-
-export function formatToastMessageInteraction(toast: IToastMessagePayload, context: IUIKitInteraction): IUIKitToastMessageInteraction {
-    if (UIKitInteractionType.TOAST_MESSAGE !== context.type) {
-        throw new Error(`Invalid type "${context.type}" for error interaction`);
-    }
-
-    return {
-        appId: context.appId,
-        type: UIKitInteractionType.TOAST_MESSAGE,
-        triggerId: context.triggerId,
-        toast,
     };
 }

--- a/src/server/accessors/UIController.ts
+++ b/src/server/accessors/UIController.ts
@@ -1,13 +1,7 @@
 import type { IUIController } from '../../definition/accessors';
 import type { IUIKitErrorInteractionParam, IUIKitInteractionParam, IUIKitSurfaceViewParam } from '../../definition/accessors/IUIController';
-import type { IToastMessagePayload } from '../../definition/ui/IToastMessagePaylaod';
 import { UIKitInteractionType, UIKitSurfaceType } from '../../definition/uikit';
-import {
-    formatContextualBarInteraction,
-    formatErrorInteraction,
-    formatModalInteraction,
-    formatToastMessageInteraction,
-} from '../../definition/uikit/UIKitInteractionPayloadFormatter';
+import { formatContextualBarInteraction, formatErrorInteraction, formatModalInteraction } from '../../definition/uikit/UIKitInteractionPayloadFormatter';
 import type { IUIKitContextualBarViewParam, IUIKitModalViewParam } from '../../definition/uikit/UIKitInteractionResponder';
 import type { IUser } from '../../definition/users';
 import type { AppBridges, UiInteractionBridge } from '../bridges';
@@ -70,16 +64,6 @@ export class UIController implements IUIController {
             case UIKitSurfaceType.MODAL:
                 return this.openModal(viewWithIds, context, user, true);
         }
-    }
-
-    public dispatchToastMessage(toast: IToastMessagePayload, context: IUIKitInteractionParam, user: IUser) {
-        const interactionContext = {
-            ...context,
-            type: UIKitInteractionType.TOAST_MESSAGE,
-            appId: this.appId,
-        };
-
-        return this.uiInteractionBridge.doNotifyUser(user, formatToastMessageInteraction(toast, interactionContext), this.appId);
     }
 
     public setViewError(errorInteraction: IUIKitErrorInteractionParam, context: IUIKitInteractionParam, user: IUser) {


### PR DESCRIPTION
This reverts commit cd85e757933f9bf84411bf9cc66ea47eab099117.

# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

Reverting #657 

# Why? :thinking:
<!--Additional explanation if needed-->

We should consider a different approach that avoid use toast messages as an exclusive ui-interaction.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
