### PR TITLE
Create mocks to call accessors from Deno

### DIFF
--- a/deno-runtime/deno.jsonc
+++ b/deno-runtime/deno.jsonc
@@ -1,5 +1,6 @@
 {
     "imports": {
+        "@rocket.chat/apps-engine/": "./../src/",
         "acorn": "npm:acorn@8.10.0",
         "acorn-walk": "npm:acorn-walk@8.2.0",
         "astring": "npm:astring@1.8.6"

--- a/deno-runtime/lib/accessors/mod.ts
+++ b/deno-runtime/lib/accessors/mod.ts
@@ -1,11 +1,61 @@
+import { IAppAccessors } from '@rocket.chat/apps-engine/definition/accessors/IAppAccessors.ts';
+import { IEnvironmentWrite } from '@rocket.chat/apps-engine/definition/accessors/IEnvironmentWrite.ts';
+import { IEnvironmentRead } from '@rocket.chat/apps-engine/definition/accessors/IEnvironmentRead.ts';
 
 export function proxify(namespace: string) {
-    return new Proxy({}, {
-        get(target: unknown, prop: string): unknown {
-            return (...args: unknown[]) => {
-                return {};
-            };
-        }
-    })
+    return new Proxy(
+        {},
+        {
+            get(target: unknown, prop: string): unknown {
+                return (...args: unknown[]) => {
+                    return {};
+                };
+            },
+        },
+    );
 }
 
+export class AppAccessors {
+    private environmentReader?: IEnvironmentRead;
+    private defaultAppAccessors?: IAppAccessors;
+    private environmentWriter?: IEnvironmentWrite;
+
+    constructor(private readonly appId: string) {}
+
+    public getEnvironmentReader() {
+        if (!this.environmentReader) {
+            this.environmentReader = {
+                getSettings: this.getSettingsReader(),
+                getServerSettings: this.getServerSettingsReader(),
+                getEnvironmentVariables: this.getEnvironmentVariablesReader(),
+            }
+        }
+
+        return this.environmentReader;
+    }
+
+    public getEnvironmentWriter() {
+        if (!this.environmentWriter) {
+            this.environmentWriter = {
+                getSettings: this.getSettingsUpdater(),
+                getServerSettings: this.getServerSettingsUpdater(),
+            }
+        }
+
+        return this.environmentWriter;
+    }
+
+    public getDefaultAppAccessors() {
+        if (!this.defaultAppAccessors) {
+            this.defaultAppAccessors = {
+                environmentReader: this.getEnvironmentReader(),
+                environmentWriter: this.getEnvironmentWriter(),
+                reader: this.getReader(),
+                http: this.getHttp(),
+                providedApiEndpoints: this.getProvidedApiEndpoints(),
+            }
+        }
+
+        return this.defaultAppAccessors;
+    }
+}

--- a/deno-runtime/lib/messenger.ts
+++ b/deno-runtime/lib/messenger.ts
@@ -2,12 +2,24 @@ export type JSONRPC_Message = {
     jsonrpc: '2.0-rc';
 };
 
-export type SuccessResponse = JSONRPC_Message & {
+export type RequestDescriptor = {
+    method: string;
+    params: any[];
+};
+
+export type Request = JSONRPC_Message &
+    RequestDescriptor & {
+        id: string;
+    };
+
+export type SuccessResponseDescriptor = {
     id: string;
     result: any;
 };
 
-export type ErrorResponse = JSONRPC_Message & {
+export type SuccessResponse = JSONRPC_Message & SuccessResponseDescriptor;
+
+export type ErrorResponseDescriptor = {
     error: {
         code: number;
         message: string;
@@ -16,11 +28,56 @@ export type ErrorResponse = JSONRPC_Message & {
     id: string | null;
 };
 
-export type JSONRPC_Response = SuccessResponse | ErrorResponse;
+export type ErrorResponse = JSONRPC_Message & ErrorResponseDescriptor;
+
+export type Response = SuccessResponse | ErrorResponse;
+
+export function isJSONRPCMessage(message: object): message is JSONRPC_Message {
+    return 'jsonrpc' in message && message['jsonrpc'] === '2.0-rc';
+}
+
+export function isRequest(message: object): message is Request {
+    return isJSONRPCMessage(message) && 'method' in message && 'params' in message && 'id' in message;
+}
+
+export function isResponse(message: object): message is Response {
+    return isJSONRPCMessage(message) && ('result' in message || 'error' in message);
+}
+
+export function isErrorResponse(response: Response): response is ErrorResponse {
+    return 'error' in response;
+}
+
+export function isSuccessResponse(response: Response): response is SuccessResponse {
+    return 'result' in response;
+}
 
 const encoder = new TextEncoder();
+export const RPCResponseObserver = new EventTarget();
 
-export async function errorResponse({ error: { message, code = -32000, data }, id }: Omit<ErrorResponse, 'jsonrpc'>): Promise<void> {
+export async function serverParseError(): Promise<void> {
+    const rpc: ErrorResponse = {
+        jsonrpc: '2.0-rc',
+        id: null,
+        error: { message: 'Parse error', code: -32700 },
+    };
+
+    const encoded = encoder.encode(JSON.stringify(rpc));
+    await Deno.stdout.write(encoded);
+}
+
+export async function serverMethodNotFound(id: string): Promise<void> {
+    const rpc: ErrorResponse = {
+        jsonrpc: '2.0-rc',
+        id,
+        error: { message: 'Method not found', code: -32601 },
+    };
+
+    const encoded = encoder.encode(JSON.stringify(rpc));
+    await Deno.stdout.write(encoded);
+}
+
+export async function errorResponse({ error: { message, code = -32000, data }, id }: ErrorResponseDescriptor): Promise<void> {
     const rpc: ErrorResponse = {
         jsonrpc: '2.0-rc',
         id,
@@ -31,12 +88,40 @@ export async function errorResponse({ error: { message, code = -32000, data }, i
     Deno.stdout.write(encoded);
 }
 
-export async function successResponse(id: string, ...result: unknown[]): Promise<void> {
+export async function successResponse({ id, result }: SuccessResponseDescriptor): Promise<void> {
     const rpc: SuccessResponse = {
         jsonrpc: '2.0-rc',
         id,
         result,
     };
+
     const encoded = encoder.encode(JSON.stringify(rpc));
     await Deno.stdout.write(encoded);
+}
+
+export async function sendRequest(requestDescriptor: RequestDescriptor): Promise<Request> {
+    const request: Request = {
+        jsonrpc: '2.0-rc',
+        id: Math.random().toString(36).slice(2),
+        ...requestDescriptor,
+    };
+
+    const encoded = encoder.encode(JSON.stringify(request));
+    await Deno.stdout.write(encoded);
+
+    return new Promise((resolve, reject) => {
+        const handler = (event: Event) => {
+            if (event instanceof ErrorEvent) {
+                reject(event.error);
+            }
+
+            if (event instanceof CustomEvent) {
+                resolve(event.detail);
+            }
+
+            RPCResponseObserver.removeEventListener(`response:${request.id}`, handler);
+        };
+
+        RPCResponseObserver.addEventListener(`response:${request.id}`, handler);
+    });
 }

--- a/src/server/runtime/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/AppsEngineDenoRuntime.ts
@@ -1,8 +1,9 @@
 import * as child_process from 'child_process';
 import * as path from 'path';
 import { EventEmitter } from 'stream';
-import { AppAccessorManager, AppApiManager } from '../managers';
-import { AppManager } from '../AppManager';
+
+import type { AppAccessorManager, AppApiManager } from '../managers';
+import type { AppManager } from '../AppManager';
 
 export type AppRuntimeParams = {
     appId: string;
@@ -77,7 +78,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         this.sendRequest({ method: 'construct', params: [this.appId, this.appSource] });
     }
 
-    private async sendRequest(message: Record<string, unknown>): Promise<unknown> {
+    public async sendRequest(message: Record<string, unknown>): Promise<unknown> {
         const id = String(Math.random()).substring(2);
 
         this.deno.stdin.write(JSON.stringify({ id, ...message }));
@@ -165,12 +166,14 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
 type ExecRequestContext = {
     method: string;
     params: Record<string, unknown>;
-    namespace: string; // Use a namespace notation in the `method` property for this
+    namespace?: string; // Use a namespace notation in the `method` property for this
 };
 
 export class AppsEngineDenoRuntime {
     private readonly subprocesses: Record<string, DenoRuntimeSubprocessController> = {};
+
     private readonly accessorManager: AppAccessorManager;
+
     private readonly apiManager: AppApiManager;
 
     constructor(manager: AppManager) {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
We need to create accessor mocks in Deno that will call the Node process.

The mocks can be proxies that will issue a Request message to the Node process that will actually perform the method call in the appropriate accessor, returning a Promise that will resolve when Node sends a Response message to the initiating Request.

On the Apps-Engine runtime, this request will be handled by the DenoRuntimeSubprocessController instance associated with the originating subprocess
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
