### PR TITLE
Create the AppObjectRegistry

### DIFF
--- a/deno-runtime/AppObjectRegistry.ts
+++ b/deno-runtime/AppObjectRegistry.ts
@@ -1,0 +1,24 @@
+export const AppObjectRegistry = new class {
+    registry: Record<string, unknown> = {};
+
+    public get(key: string): unknown {
+        return this.registry[key];
+    }
+
+    public set(key: string, value: unknown): void {
+        this.registry[key] = value;
+    }
+
+    public has(key: string): boolean {
+        return key in this.registry;
+    }
+
+    public delete(key: string): void {
+        delete this.registry[key];
+    }
+
+    public clear(): void {
+        this.registry = {};
+    }
+}
+

--- a/deno-runtime/main.ts
+++ b/deno-runtime/main.ts
@@ -12,18 +12,7 @@ import { createRequire } from 'node:module';
 import { sanitizeDeprecatedUsage } from "./lib/sanitizeDeprecatedUsage.ts";
 import { AppAccessorsInstance } from "./lib/accessors/mod.ts";
 import * as Messenger from "./lib/messenger.ts";
-
-export const AppObjectRegistry = new class {
-    registry: Record<string, unknown> = {};
-
-    public get(key: string): unknown {
-        return this.registry[key];
-    }
-
-    public set(key: string, value: unknown): void {
-        this.registry[key] = value;
-    }
-}
+import { AppObjectRegistry } from "./AppObjectRegistry.ts";
 
 const require = createRequire(import.meta.url);
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
The new `AppObjectRegistry` will hold references to instances of objects created by the app to pass to the `ConfigurationExtend` or `ConfigurationModify` accessors
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
