### PR TITLE
Adapted config accessors

### DIFF
--- a/deno-runtime/lib/accessors/_test.ts
+++ b/deno-runtime/lib/accessors/_test.ts
@@ -1,22 +1,22 @@
 import { beforeEach, describe, it } from 'https://deno.land/std@0.203.0/testing/bdd.ts';
 import { assertEquals } from "https://deno.land/std@0.203.0/assert/assert_equals.ts";
 
-import { AppAccessors, getProxify } from "./mod.ts";
+import { AppAccessors } from "./mod.ts";
 import { AppObjectRegistry } from "../../AppObjectRegistry.ts";
 
 describe('AppAccessors', () => {
     let appAccessors: AppAccessors;
-    const proxify = getProxify((r) => Promise.resolve({
+    const senderFn = (r: object) => Promise.resolve({
         id: Math.random().toString(36).substring(2),
         jsonrpc: '2.0',
         result: r,
         serialize() {
             return JSON.stringify(this);
         }
-    }));
+    });
 
     beforeEach(() => {
-        appAccessors = new AppAccessors(proxify);
+        appAccessors = new AppAccessors(senderFn);
         AppObjectRegistry.clear();
     });
 

--- a/src/definition/api/IApiEndpoint.ts
+++ b/src/definition/api/IApiEndpoint.ts
@@ -26,6 +26,14 @@ export interface IApiEndpoint {
     authRequired?: boolean;
 
     /**
+     * The methods that are available for this endpoint.
+     * This property is provided by the Runtime and should not be set manually.
+     *
+     * Its values are used on the Apps-Engine to validate the request method.
+     */
+    _availableMethods?: string[];
+
+    /**
      * Called whenever the publically accessible url for this App is called,
      * if you handle the methods differently then split it out so your code doesn't get too big.
      */

--- a/src/server/managers/AppApi.ts
+++ b/src/server/managers/AppApi.ts
@@ -7,8 +7,6 @@ import type { ProxiedApp } from '../ProxiedApp';
 import type { AppLogStorage } from '../storage';
 import type { AppAccessorManager } from './AppAccessorManager';
 
-const methods: Array<string> = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'];
-
 export class AppApi {
     public readonly computedPath: string;
 
@@ -36,7 +34,7 @@ export class AppApi {
 
         this.computedPath = `${this.basePath}/${endpoint.path}`;
 
-        this.implementedMethods = methods.filter((m) => typeof (endpoint as any)[m] === 'function');
+        this.implementedMethods = endpoint._availableMethods;
     }
 
     public async runExecutor(request: IApiRequest, logStorage: AppLogStorage, accessors: AppAccessorManager): Promise<IApiResponse> {
@@ -45,7 +43,7 @@ export class AppApi {
         const { method } = request;
 
         // Ensure the api has the property before going on
-        if (typeof this.endpoint[method] !== 'function') {
+        if (!this.endpoint[method]) {
             return;
         }
 

--- a/src/server/runtime/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/AppsEngineDenoRuntime.ts
@@ -157,6 +157,12 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         const managerOrigin = accessorMethods.shift();
         const tailMethodName = accessorMethods.pop();
 
+        if (managerOrigin === 'api' && tailMethodName === 'listApis') {
+            const result = this.api.listApis(this.appId);
+
+            return jsonrpc.success(id, result);
+        }
+
         /**
          * At this point, the accessorMethods array will contain the path to the accessor from the origin (AppAccessorManager)
          * The accessor is the one that contains the actual method the app wants to call
@@ -196,13 +202,12 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         ) => {
             const origin = accessorManager[managerOrigin](this.appId);
 
-            // These will need special treatment
-            if (managerOrigin === 'getConfigurationExtend' || managerOrigin === 'getConfigurationModify') {
-                return origin[accessorMethods[0] as keyof typeof origin];
-            }
-
             if (managerOrigin === 'getHttp' || managerOrigin === 'getPersistence') {
                 return origin;
+            }
+
+            if (managerOrigin === 'getConfigurationExtend' || managerOrigin === 'getConfigurationModify') {
+                return origin[accessorMethods[0] as keyof typeof origin];
             }
 
             let accessor = origin;

--- a/tests/test-data/utilities.ts
+++ b/tests/test-data/utilities.ts
@@ -244,6 +244,8 @@ export class TestData {
             endpoints: [
                 {
                     path,
+                    // The move to the Deno runtime now requires us to manually set what methods are available
+                    _availableMethods: ['get'],
                     get(
                         request: IApiRequest,
                         endpoint: IApiEndpointInfo,


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Config accessors are used by apps to register several components which are not serializable because they include functions that need to be called in the future.

Here we adapt the calls to store instances when needed
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
