### PR TITLE
Prevent proxies from sending toJSON calls via IPC

### DIFF
--- a/deno-runtime/lib/accessors/mod.ts
+++ b/deno-runtime/lib/accessors/mod.ts
@@ -14,9 +14,9 @@ import type { IVideoConfProvider } from '@rocket.chat/apps-engine/definition/vid
 
 import * as Messenger from '../messenger.ts';
 import { AppObjectRegistry } from '../../AppObjectRegistry.ts';
-import { ModifyCreator } from "./modify/ModifyCreator.ts";
-import { ModifyUpdater } from "./modify/ModifyUpdater.ts";
-import { ModifyExtender } from "./modify/ModifyExtender.ts";
+import { ModifyCreator } from './modify/ModifyCreator.ts';
+import { ModifyUpdater } from './modify/ModifyUpdater.ts';
+import { ModifyExtender } from './modify/ModifyExtender.ts';
 
 const httpMethods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const;
 
@@ -44,10 +44,12 @@ export class AppAccessors {
                     get:
                         (_target: unknown, prop: string) =>
                         (...params: unknown[]) =>
-                            senderFn({
-                                method: `accessor:${namespace}:${prop}`,
-                                params,
-                            }),
+                            prop === 'toJSON'
+                                ? {}
+                                : senderFn({
+                                      method: `accessor:${namespace}:${prop}`,
+                                      params,
+                                  }),
                 },
             ) as T;
     }

--- a/deno-runtime/lib/accessors/modify/ModifyCreator.ts
+++ b/deno-runtime/lib/accessors/modify/ModifyCreator.ts
@@ -44,6 +44,10 @@ export class ModifyCreator implements IModifyCreator {
                         return () => Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
                     }
 
+                    if (prop === 'toJSON') {
+                        return () => ({});
+                    }
+
                     return (...params: unknown[]) =>
                         this.senderFn({
                             method: `accessor:getModifier:getCreator:getLivechatCreator:${prop}`,
@@ -61,10 +65,12 @@ export class ModifyCreator implements IModifyCreator {
                 get:
                     (_target: unknown, prop: string) =>
                     (...params: unknown[]) =>
-                        this.senderFn({
-                            method: `accessor:getModifier:getCreator:getUploadCreator:${prop}`,
-                            params,
-                        }),
+                        prop === 'toJSON'
+                            ? {}
+                            : this.senderFn({
+                                  method: `accessor:getModifier:getCreator:getUploadCreator:${prop}`,
+                                  params,
+                              }),
             },
         ) as IUploadCreator;
     }

--- a/deno-runtime/lib/accessors/modify/ModifyUpdater.ts
+++ b/deno-runtime/lib/accessors/modify/ModifyUpdater.ts
@@ -32,10 +32,12 @@ export class ModifyUpdater implements IModifyUpdater {
                 get:
                     (_target: unknown, prop: string) =>
                     (...params: unknown[]) =>
-                        this.senderFn({
-                            method: `accessor:getModifier:getUpdater:getLivechatUpdater:${prop}`,
-                            params,
-                        }),
+                        prop === 'toJSON'
+                            ? {}
+                            : this.senderFn({
+                                  method: `accessor:getModifier:getUpdater:getLivechatUpdater:${prop}`,
+                                  params,
+                              }),
             },
         ) as ILivechatUpdater;
     }
@@ -47,10 +49,12 @@ export class ModifyUpdater implements IModifyUpdater {
                 get:
                     (_target: unknown, prop: string) =>
                     (...params: unknown[]) =>
-                        this.senderFn({
-                            method: `accessor:getModifier:getUpdater:getUserUpdater:${prop}`,
-                            params,
-                        }),
+                        prop === 'toJSON'
+                            ? {}
+                            : this.senderFn({
+                                  method: `accessor:getModifier:getUpdater:getUserUpdater:${prop}`,
+                                  params,
+                              }),
             },
         ) as IUserUpdater;
     }

--- a/src/definition/App.ts
+++ b/src/definition/App.ts
@@ -220,4 +220,9 @@ export abstract class App implements IApp {
         this.logger.debug(`The status is now: ${status}`);
         this.status = status;
     }
+
+    // Avoid leaking references if object is logged or sent over IPC
+    public toJSON(): Record<string, any> {
+        return this.info;
+    }
 }

--- a/src/definition/App.ts
+++ b/src/definition/App.ts
@@ -221,7 +221,7 @@ export abstract class App implements IApp {
         this.status = status;
     }
 
-    // Avoid leaking references if object is logged or sent over IPC
+    // Avoid leaking references if object is serialized (e.g. to be sent over IPC)
     public toJSON(): Record<string, any> {
         return this.info;
     }

--- a/src/server/runtime/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/AppsEngineDenoRuntime.ts
@@ -224,7 +224,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         // Prevent app from trying to get properties from the manager that
         // are not intended for public access
         if (!isValidOrigin(managerOrigin)) {
-            throw new Error('Invalid accessor namespace');
+            throw new Error(`Invalid accessor namespace "${managerOrigin}"`);
         }
 
         // Need to fix typing of return value
@@ -250,7 +250,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
                 const method = accessor[methodName as keyof typeof accessor] as unknown;
 
                 if (typeof method !== 'function') {
-                    throw new Error('Invalid accessor method');
+                    throw new Error(`Invalid accessor method "${methodName}"`);
                 }
 
                 accessor = method.apply(accessor);
@@ -264,7 +264,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         const tailMethod = accessor[tailMethodName as keyof typeof accessor] as unknown;
 
         if (typeof tailMethod !== 'function') {
-            throw new Error('Invalid accessor method');
+            throw new Error(`Invalid accessor method "${tailMethodName}"`);
         }
 
         const result = await tailMethod.apply(accessor, params);


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
The proxies used to send method calls as request over IPC ended up also sending calls to the `toJSON` method as a request. This, of course, makes no sense and only causes problems.

This PR also adds a `toJSON` implementation to the `App` abstract class, as the app instance can be sent over for configuration methods if the object sent has a reference to the App instance. E.g. instantiating a slashcommand class that takes the instace of the App as parameter via constructor.
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
