### PR TITLE
Remove method `hasMethod` from ProxiedApp and its usages

### DIFF
--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -45,10 +45,6 @@ export class ProxiedApp implements IApp {
         return this.storageItem.implemented;
     }
 
-    public hasMethod(method: AppMethod): boolean {
-        return true; // TODO: needs refactor, remove usages
-    }
-
     public setupLogger(method: `${AppMethod}`): AppConsole {
         const logger = new AppConsole(method);
 

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -863,9 +863,6 @@ export class AppListenerManager {
         })(type);
 
         const app = this.manager.getOneById(appId);
-        if (!app.hasMethod(method)) {
-            return;
-        }
 
         const interactionContext = ((interactionType: UIKitIncomingInteractionType, interactionData: IUIKitLivechatIncomingInteraction) => {
             const { actionId, message, visitor, room, triggerId, container } = interactionData;

--- a/src/server/managers/AppSlashCommand.ts
+++ b/src/server/managers/AppSlashCommand.ts
@@ -34,10 +34,6 @@ export class AppSlashCommand {
         this.isRegistered = true;
     }
 
-    public canBeRan(method: AppMethod): boolean {
-        return this.app.hasMethod(method);
-    }
-
     public async runExecutorOrPreviewer(
         method: AppMethod._COMMAND_EXECUTOR | AppMethod._COMMAND_PREVIEWER,
         context: SlashCommandContext,

--- a/src/server/managers/AppVideoConfProvider.ts
+++ b/src/server/managers/AppVideoConfProvider.ts
@@ -21,10 +21,6 @@ export class AppVideoConfProvider {
         this.isRegistered = true;
     }
 
-    public canBeRan(method: AppMethod): boolean {
-        return this.app.hasMethod(method);
-    }
-
     public async runIsFullyConfigured(logStorage: AppLogStorage, accessors: AppAccessorManager): Promise<boolean> {
         if (typeof this.provider[AppMethod._VIDEOCONF_IS_CONFIGURED] !== 'function') {
             return true;

--- a/tests/server/accessors/AppAccessors.spec.ts
+++ b/tests/server/accessors/AppAccessors.spec.ts
@@ -49,9 +49,6 @@ export class AppAccessorsTestFixture {
             getStatus() {
                 return AppStatus.AUTO_ENABLED;
             },
-            hasMethod(method: AppMethod): boolean {
-                return true;
-            },
             setupLogger(method: AppMethod): AppConsole {
                 return new AppConsole(method);
             },

--- a/tests/server/managers/AppApiManager.spec.ts
+++ b/tests/server/managers/AppApiManager.spec.ts
@@ -55,9 +55,6 @@ export class AppApiManagerTestFixture {
             getStatus() {
                 return AppStatus.AUTO_ENABLED;
             },
-            hasMethod(method: AppMethod): boolean {
-                return true;
-            },
             setupLogger(method: AppMethod): AppConsole {
                 return new AppConsole(method);
             },

--- a/tests/server/managers/AppSlashCommand.spec.ts
+++ b/tests/server/managers/AppSlashCommand.spec.ts
@@ -1,6 +1,5 @@
 import { Expect, SetupFixture, Test } from 'alsatian';
 
-import { AppMethod } from '../../../src/definition/metadata';
 import type { ISlashCommand } from '../../../src/definition/slashcommands';
 import { AppSlashCommand } from '../../../src/server/managers/AppSlashCommand';
 import type { ProxiedApp } from '../../../src/server/ProxiedApp';
@@ -10,11 +9,7 @@ export class AppSlashCommandRegistrationTestFixture {
 
     @SetupFixture
     public setupFixture() {
-        this.mockApp = {
-            hasMethod(method: AppMethod): boolean {
-                return true;
-            },
-        } as ProxiedApp;
+        this.mockApp = {} as ProxiedApp;
     }
 
     @Test()
@@ -30,7 +25,5 @@ export class AppSlashCommandRegistrationTestFixture {
         Expect(ascr.isDisabled).toBe(false);
         Expect(ascr.isEnabled).toBe(true);
         Expect(ascr.isRegistered).toBe(true);
-
-        Expect(ascr.canBeRan(AppMethod._COMMAND_EXECUTOR)).toBe(true);
     }
 }

--- a/tests/server/managers/AppSlashCommandManager.spec.ts
+++ b/tests/server/managers/AppSlashCommandManager.spec.ts
@@ -54,9 +54,6 @@ export class AppSlashCommandManagerTestFixture {
             getStatus() {
                 return AppStatus.AUTO_ENABLED;
             },
-            hasMethod(method: AppMethod): boolean {
-                return true;
-            },
             setupLogger(method: AppMethod): AppConsole {
                 return new AppConsole(method);
             },

--- a/tests/server/managers/AppVideoConfProvider.spec.ts
+++ b/tests/server/managers/AppVideoConfProvider.spec.ts
@@ -1,6 +1,5 @@
 import { Expect, SetupFixture, Test } from 'alsatian';
 
-import { AppMethod } from '../../../src/definition/metadata';
 import type { IVideoConfProvider } from '../../../src/definition/videoConfProviders';
 import { AppVideoConfProvider } from '../../../src/server/managers/AppVideoConfProvider';
 import type { ProxiedApp } from '../../../src/server/ProxiedApp';
@@ -10,11 +9,7 @@ export class AppSlashCommandRegistrationTestFixture {
 
     @SetupFixture
     public setupFixture() {
-        this.mockApp = {
-            hasMethod(method: AppMethod): boolean {
-                return true;
-            },
-        } as ProxiedApp;
+        this.mockApp = {} as ProxiedApp;
     }
 
     @Test()
@@ -26,8 +21,5 @@ export class AppSlashCommandRegistrationTestFixture {
 
         ascr.hasBeenRegistered();
         Expect(ascr.isRegistered).toBe(true);
-
-        Expect(ascr.canBeRan(AppMethod._VIDEOCONF_GENERATE_URL)).toBe(true);
-        Expect(ascr.canBeRan(AppMethod._VIDEOCONF_CUSTOMIZE_URL)).toBe(true);
     }
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Remove unused method
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
