### PR TITLE
Refactor `IApp.getStatus` implementation and usages

### DIFF
--- a/src/definition/App.ts
+++ b/src/definition/App.ts
@@ -37,7 +37,7 @@ export abstract class App implements IApp {
         this.setStatus(AppStatus.CONSTRUCTED);
     }
 
-    public getStatus(): AppStatus {
+    public async getStatus(): Promise<AppStatus> {
         return this.status;
     }
 

--- a/src/definition/IApp.ts
+++ b/src/definition/IApp.ts
@@ -10,7 +10,7 @@ export interface IApp {
      *
      * @return {AppStatus} the status/state of the App
      */
-    getStatus(): AppStatus;
+    getStatus(): Promise<AppStatus>;
 
     /**
      * Get the name of this App.

--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -1,5 +1,5 @@
 import type { IAppAccessors, ILogger } from '../definition/accessors';
-import { AppStatus } from '../definition/AppStatus';
+import type { AppStatus } from '../definition/AppStatus';
 import { AppsEngineException } from '../definition/exceptions';
 import type { IApp } from '../definition/IApp';
 import type { IAppAuthorInfo, IAppInfo } from '../definition/metadata';
@@ -65,9 +65,8 @@ export class ProxiedApp implements IApp {
         }
     }
 
-    public getStatus(): AppStatus {
-        // return this.appRuntime.getStatus();
-        return AppStatus.UNKNOWN; // TODO: need to circle back on this one
+    public async getStatus(): Promise<AppStatus> {
+        return this.appRuntime.getStatus();
     }
 
     public async setStatus(status: AppStatus, silent?: boolean): Promise<void> {

--- a/src/server/managers/AppApiManager.ts
+++ b/src/server/managers/AppApiManager.ts
@@ -114,7 +114,7 @@ export class AppApiManager {
 
         const app = this.manager.getOneById(appId);
 
-        if (!app || AppStatusUtils.isDisabled(app.getStatus())) {
+        if (!app || AppStatusUtils.isDisabled(await app.getStatus())) {
             // Just in case someone decides to do something they shouldn't
             // let's ensure the app actually exists
             return {

--- a/src/server/managers/AppSchedulerManager.ts
+++ b/src/server/managers/AppSchedulerManager.ts
@@ -54,7 +54,7 @@ export class AppSchedulerManager {
             }
 
             const app = this.manager.getOneById(appId);
-            const status = app.getStatus();
+            const status = await app.getStatus();
             const previousStatus = app.getPreviousStatus();
 
             const isNotToRunJob = this.isNotToRunJob(status, previousStatus);

--- a/src/server/managers/AppSlashCommandManager.ts
+++ b/src/server/managers/AppSlashCommandManager.ts
@@ -333,7 +333,7 @@ export class AppSlashCommandManager {
 
         const app = this.manager.getOneById(this.touchedCommandsToApps.get(cmd));
 
-        if (!app || AppStatusUtils.isDisabled(app.getStatus())) {
+        if (!app || AppStatusUtils.isDisabled(await app.getStatus())) {
             // Just in case someone decides to do something they shouldn't
             // let's ensure the app actually exists
             return;
@@ -352,7 +352,7 @@ export class AppSlashCommandManager {
 
         const app = this.manager.getOneById(this.touchedCommandsToApps.get(cmd));
 
-        if (!app || AppStatusUtils.isDisabled(app.getStatus())) {
+        if (!app || AppStatusUtils.isDisabled(await app.getStatus())) {
             // Just in case someone decides to do something they shouldn't
             // let's ensure the app actually exists
             return;
@@ -384,7 +384,7 @@ export class AppSlashCommandManager {
 
         const app = this.manager.getOneById(this.touchedCommandsToApps.get(cmd));
 
-        if (!app || AppStatusUtils.isDisabled(app.getStatus())) {
+        if (!app || AppStatusUtils.isDisabled(await app.getStatus())) {
             // Just in case someone decides to do something they shouldn't
             // let's ensure the app actually exists
             return;

--- a/tests/server/accessors/AppAccessors.spec.ts
+++ b/tests/server/accessors/AppAccessors.spec.ts
@@ -47,7 +47,7 @@ export class AppAccessorsTestFixture {
                 return 'testing';
             },
             getStatus() {
-                return AppStatus.AUTO_ENABLED;
+                return Promise.resolve(AppStatus.AUTO_ENABLED);
             },
             hasMethod(method: AppMethod): boolean {
                 return true;

--- a/tests/server/managers/AppApiManager.spec.ts
+++ b/tests/server/managers/AppApiManager.spec.ts
@@ -53,7 +53,7 @@ export class AppApiManagerTestFixture {
                 return 'testing';
             },
             getStatus() {
-                return AppStatus.AUTO_ENABLED;
+                return Promise.resolve(AppStatus.AUTO_ENABLED);
             },
             hasMethod(method: AppMethod): boolean {
                 return true;

--- a/tests/server/managers/AppSlashCommandManager.spec.ts
+++ b/tests/server/managers/AppSlashCommandManager.spec.ts
@@ -52,7 +52,7 @@ export class AppSlashCommandManagerTestFixture {
                 return 'testing';
             },
             getStatus() {
-                return AppStatus.AUTO_ENABLED;
+                return Promise.resolve(AppStatus.AUTO_ENABLED);
             },
             hasMethod(method: AppMethod): boolean {
                 return true;

--- a/tests/server/misc/DisabledApp.spec.ts
+++ b/tests/server/misc/DisabledApp.spec.ts
@@ -31,7 +31,7 @@ export class DisabledAppTestFixture {
         Expect(disabledApp).toBeDefined();
         Expect(disabledApp.getLogger()).toBeDefined();
         Expect(disabledApp.getInfo()).toEqual(this.expectedInfo);
-        Expect(disabledApp.getStatus()).toEqual(AppStatus.COMPILER_ERROR_DISABLED);
+        Expect(await disabledApp.getStatus()).toEqual(AppStatus.COMPILER_ERROR_DISABLED);
         Expect(() => disabledApp.onEnable()).not.toThrow();
         Expect(await disabledApp.onEnable()).toEqual(false);
     }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
`getStatus` now needs to be async because we need to ask the Deno subprocess about the app's status
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
