### PR TITLE
Fix app construct handler

### DIFF
--- a/deno-runtime/handlers/app/construct.ts
+++ b/deno-runtime/handlers/app/construct.ts
@@ -19,7 +19,7 @@ function buildRequire(): (module: string) => unknown {
         }
 
         if (module.startsWith('@rocket.chat/apps-engine')) {
-            const path = module.concat('.js');
+            const path = module;
             return require(path);
         }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
The request for `app:construct` can be split into two due to the size of the payload, so now requests sent from Node will have a `MESSAGE_SEPARATOR` sequence and Deno will buffer any chunk that doesn't have one

Also introduced an `await` in the `parseOutput` function to avoid unhandled promise rejections
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
