### PR TITLE
Improve incoming message handling on both Node and Deno

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -268,7 +268,12 @@ export class AppManager {
                 console.warn(`Error while compiling the App "${item.info.name} (${item.id})":`);
                 console.error(e);
 
-                const prl = new ProxiedApp(this, item, {} as DenoRuntimeSubprocessController);
+                const prl = new ProxiedApp(this, item, {
+                    // Maybe we should have an "EmptyRuntime" class for this?
+                    getStatus() {
+                        return AppStatus.COMPILER_ERROR_DISABLED;
+                    },
+                } as unknown as DenoRuntimeSubprocessController);
                 this.apps.set(item.id, prl);
             }
         }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Both ends of the socket now can receive multiple messages or incomplete messages and will handle this appropriately
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
