### PR TITLE
fix: soft lock when an app uses its accessors

### DIFF
--- a/deno-runtime/main.ts
+++ b/deno-runtime/main.ts
@@ -124,7 +124,7 @@ async function main() {
                 const JSONRPCMessage = Messenger.parseMessage(messageBuffer.join(''));
 
                 if (Messenger.isRequest(JSONRPCMessage)) {
-                    await requestRouter(JSONRPCMessage);
+                    void requestRouter(JSONRPCMessage);
                     continue;
                 }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

Change deno's main loop to work on incoming messages asynchronously.

# Why? :thinking:
<!--Additional explanation if needed-->

If the deno process tries to request something from the main process and wait for its results, it would put itself into a soft lock, as the response event is triggered by the main loop as well. 

If the queue is process asynchronously, then the deno process can continue to process new messages even while an old one is waiting for something.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
