### PR TITLE
Add undo step to recover from installation errors

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -549,6 +549,8 @@ export class AppManager {
         // the App instance from the source.
         const app = await this.getCompiler().toSandBox(this, descriptor, result);
 
+        undoSteps.push(() => app.getDenoRuntime().stopApp());
+
         // Create a user for the app
         try {
             await this.createAppUser(result.info);


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Add undo step to installation process to stop the subprocess in case there are errors during installation.

Without this, further attempts to install the same app will result in error because the runtime manager will reject saying the app already has a runtime associated with it
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
