### PR TITLE
Remove accessors being sent as parameters on settings event handlers

### DIFF
--- a/src/server/managers/AppSettingsManager.ts
+++ b/src/server/managers/AppSettingsManager.ts
@@ -39,12 +39,7 @@ export class AppSettingsManager {
             throw new Error('No setting found for the App by the provided id.');
         }
 
-        const configModify = this.manager.getAccessorManager().getConfigurationModify(rl.getID());
-        const reader = this.manager.getAccessorManager().getReader(rl.getID());
-        const http = this.manager.getAccessorManager().getHttp(rl.getID());
-        const decoratedSetting =
-            (await rl.call(AppMethod.ON_PRE_SETTING_UPDATE, { oldSetting, newSetting: setting } as ISettingUpdateContext, configModify, reader, http)) ||
-            setting;
+        const decoratedSetting = (await rl.call(AppMethod.ON_PRE_SETTING_UPDATE, { oldSetting, newSetting: setting } as ISettingUpdateContext)) || setting;
 
         decoratedSetting.updatedAt = new Date();
         rl.getStorageItem().settings[decoratedSetting.id] = decoratedSetting;
@@ -55,6 +50,6 @@ export class AppSettingsManager {
 
         this.manager.getBridges().getAppDetailChangesBridge().doOnAppSettingsChange(appId, decoratedSetting);
 
-        await rl.call(AppMethod.ONSETTINGUPDATED, decoratedSetting, configModify, reader, http);
+        await rl.call(AppMethod.ONSETTINGUPDATED, decoratedSetting);
     }
 }

--- a/tests/server/managers/AppSettingsManager.spec.ts
+++ b/tests/server/managers/AppSettingsManager.spec.ts
@@ -129,9 +129,6 @@ export class AppSettingsManagerTestFixture {
         SpyOn(this.mockApp, 'call');
         SpyOn(this.mockApp, 'setStorageItem');
         SpyOn(this.mockBridges.getAppDetailChangesBridge(), 'doOnAppSettingsChange');
-        SpyOn(this.mockAccessors, 'getConfigurationModify');
-        SpyOn(this.mockAccessors, 'getReader');
-        SpyOn(this.mockAccessors, 'getHttp');
 
         await Expect(() => asm.updateAppSetting('fake', TestData.getSetting())).toThrowErrorAsync(Error, 'No App found by the provided id.');
         await Expect(() => asm.updateAppSetting('testing', TestData.getSetting('fake'))).toThrowErrorAsync(
@@ -146,19 +143,6 @@ export class AppSettingsManagerTestFixture {
         Expect(this.mockApp.setStorageItem).toHaveBeenCalledWith(this.mockStorageItem).exactly(1);
         Expect(this.mockBridges.getAppDetailChangesBridge().doOnAppSettingsChange).toHaveBeenCalledWith('testing', set).exactly(1);
 
-        // Accessors
-        Expect(this.mockAccessors.getConfigurationModify).toHaveBeenCalledWith('testing').exactly(1);
-        Expect(this.mockAccessors.getReader).toHaveBeenCalledWith('testing').exactly(1);
-        Expect(this.mockAccessors.getHttp).toHaveBeenCalledWith('testing').exactly(1);
-
-        Expect(this.mockApp.call)
-            .toHaveBeenCalledWith(
-                AppMethod.ONSETTINGUPDATED,
-                set,
-                this.mockAccessors.getConfigurationModify('testing'),
-                this.mockAccessors.getReader('testing'),
-                this.mockAccessors.getHttp('testing'),
-            )
-            .exactly(1);
+        Expect(this.mockApp.call).toHaveBeenCalledWith(AppMethod.ONSETTINGUPDATED, set).exactly(1);
     }
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Remove unnecessary accessor parameters from settings event handler calls as they were breaking the flow

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
