### PR TITLE
Prevent timeout if subprocess not available for getStatus

### DIFF
--- a/src/server/runtime/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/AppsEngineDenoRuntime.ts
@@ -8,10 +8,10 @@ import type { AppManager } from '../AppManager';
 import type { AppLogStorage } from '../storage';
 import type { AppBridges } from '../bridges';
 import type { IParseAppPackageResult } from '../compiler';
-import type { AppStatus } from '../../definition/AppStatus';
 import type { AppAccessorManager, AppApiManager } from '../managers';
 import type { ILoggerStorageEntry } from '../logging';
 import type { AppRuntimeManager } from '../managers/AppRuntimeManager';
+import { AppStatus } from '../../definition/AppStatus';
 
 export const ALLOWED_ACCESSOR_METHODS = [
     'getConfigurationExtend',
@@ -139,6 +139,10 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
     }
 
     public async getStatus(): Promise<AppStatus> {
+        // If the process has been terminated, we can't get the status
+        if (this.deno.exitCode !== null) {
+            return AppStatus.UNKNOWN;
+        }
         return this.sendRequest({ method: 'app:getStatus', params: [] }) as Promise<AppStatus>;
     }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Now the `getStatus` method in `DenoSubprocessController` will return `AppStatus.UNKNOWN` if the Deno process has been terminated
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
