### PR TITLE
Adopt msgpack to encode messages instead of JSON

### DIFF
--- a/deno-runtime/deno.jsonc
+++ b/deno-runtime/deno.jsonc
@@ -2,6 +2,7 @@
     "imports": {
         "@rocket.chat/apps-engine/": "./../src/",
         "@rocket.chat/ui-kit": "npm:@rocket.chat/ui-kit@^0.31.22",
+        "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2",
         "acorn": "npm:acorn@8.10.0",
         "acorn-walk": "npm:acorn-walk@8.2.0",
         "astring": "npm:astring@1.8.6",

--- a/deno-runtime/deno.lock
+++ b/deno-runtime/deno.lock
@@ -2,6 +2,7 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "npm:@msgpack/msgpack@3.0.0-beta2": "npm:@msgpack/msgpack@3.0.0-beta2",
       "npm:@rocket.chat/ui-kit@^0.31.22": "npm:@rocket.chat/ui-kit@0.31.25_@rocket.chat+icons@0.32.0",
       "npm:acorn-walk@8.2.0": "npm:acorn-walk@8.2.0",
       "npm:acorn@8.10.0": "npm:acorn@8.10.0",
@@ -12,6 +13,10 @@
       "npm:uuid@8.3.2": "npm:uuid@8.3.2"
     },
     "npm": {
+      "@msgpack/msgpack@3.0.0-beta2": {
+        "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw==",
+        "dependencies": {}
+      },
       "@rocket.chat/icons@0.32.0": {
         "integrity": "sha512-7yhhELKNLb9kUtXCvau0V+iMXraV2bOsxcPjc/ZtLR5VeeIDTeaflqRWGtLroX6f3bE+J1n5qB5zi8A4YXuH2g==",
         "dependencies": {}

--- a/deno-runtime/lib/codec.ts
+++ b/deno-runtime/lib/codec.ts
@@ -1,0 +1,35 @@
+import { Buffer } from 'node:buffer';
+import { Decoder, Encoder, ExtensionCodec } from '@msgpack/msgpack';
+
+const extensionCodec = new ExtensionCodec();
+
+extensionCodec.register({
+    type: 0,
+    encode: (object: unknown) => {
+        // We don't care about functions, but also don't want to throw an error
+        if (typeof object === 'function') {
+            return new Uint8Array(0);
+        }
+
+        return null;
+    },
+    decode: (_data: Uint8Array) => undefined,
+});
+
+// Since Deno doesn't have Buffer by default, we need to use Uint8Array
+extensionCodec.register({
+    type: 1,
+    encode: (object: unknown) => {
+        if (object instanceof Buffer) {
+            return new Uint8Array(object.buffer, object.byteOffset, object.byteLength);
+        }
+
+        return null;
+    },
+    decode: (data: Uint8Array) => {
+        return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+    },
+});
+
+export const encoder = new Encoder({ extensionCodec });
+export const decoder = new Decoder({ extensionCodec });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@rocket.chat/apps-engine",
-    "version": "1.42.0-alpha",
+    "version": "1.42.0-deno",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -917,6 +917,11 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "@msgpack/msgpack": {
+            "version": "3.0.0-beta2",
+            "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.0.0-beta2.tgz",
+            "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw=="
         },
         "@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
         "uglify-es": "^3.3.9"
     },
     "dependencies": {
+        "@msgpack/msgpack": "3.0.0-beta2",
         "adm-zip": "^0.5.9",
         "cryptiles": "^4.1.3",
         "deno-bin": "1.37.1",


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Start using msgpack to encode/decode messages on both Node and Deno

# Why? :thinking:
<!--Additional explanation if needed-->
Manually parsing from JSON was becoming very difficult because messages could be split in several different ways and keeping track of message boundaries was a headache. Msgpack does away with all that

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
