### PR TITLE
Overwrite the name `console` when evaluating the app's code in Deno

### DIFF
--- a/deno-runtime/handlers/app/construct.ts
+++ b/deno-runtime/handlers/app/construct.ts
@@ -34,9 +34,19 @@ function wrapAppCode(code: string): (require: (module: string) => unknown) => Pr
         const { Buffer } = require('buffer');
         const exports = {};
         const module = { exports };
-        const result = (async (exports,module,require,Buffer,globalThis,Deno) => {
+        const _error = console.error.bind(console);
+        const _console = {
+            log: _error,
+            error: _error,
+            debug: _error,
+            info: _error,
+            warn: _error,
+        };
+
+        const result = (async (exports,module,require,Buffer,console,globalThis,Deno) => {
             ${code};
-        })(exports,module,require,Buffer);
+        })(exports,module,require,Buffer,_console,undefined,undefined);
+
         return result.then(() => module.exports);`,
     ) as (require: (module: string) => unknown) => Promise<Record<string, unknown>>;
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Preventing the app from accessing the underlying console object and accidentally pushing content to stdout
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
