### PR TITLE
Fix codec and providedApiEndpoints

### DIFF
--- a/deno-runtime/lib/accessors/mod.ts
+++ b/deno-runtime/lib/accessors/mod.ts
@@ -25,7 +25,7 @@ const httpMethods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch']
 
 // We need to create this object first thing, as we'll handle references to it later on
 if (!AppObjectRegistry.has('apiEndpoints')) {
-    AppObjectRegistry.set('apiEndpoints', {});
+    AppObjectRegistry.set('apiEndpoints', []);
 }
 
 export class AppAccessors {
@@ -129,7 +129,7 @@ export class AppAccessors {
                 api: {
                     _proxy: this.proxify('getConfigurationExtend:api'),
                     async provideApi(api: IApi) {
-                        const apiEndpoints = AppObjectRegistry.get<Record<string, IApiEndpointMetadata>>('apiEndpoints')!;
+                        const apiEndpoints = AppObjectRegistry.get<IApiEndpointMetadata[]>('apiEndpoints')!;
 
                         api.endpoints.forEach((endpoint) => {
                             endpoint._availableMethods = httpMethods.filter((method) => typeof endpoint[method] === 'function');
@@ -143,11 +143,7 @@ export class AppAccessors {
                         // Let's call the listApis method to cache the info from the endpoints
                         // Also, since this is a side-effect, we do it async so we can return to the caller
                         senderFn({ method: 'accessor:api:listApis' })
-                            .then((response) => {
-                                const endpoints = response.result as IApiEndpointMetadata[];
-
-                                endpoints.forEach((endpoint) => (apiEndpoints[endpoint.path] = endpoint));
-                            })
+                            .then((response) => apiEndpoints.push(...(response.result as IApiEndpointMetadata[])))
                             .catch((err) => err.error);
 
                         return result;

--- a/deno-runtime/lib/codec.ts
+++ b/deno-runtime/lib/codec.ts
@@ -1,13 +1,20 @@
 import { Buffer } from 'node:buffer';
 import { Decoder, Encoder, ExtensionCodec } from '@msgpack/msgpack';
 
+import type { App as _App } from '@rocket.chat/apps-engine/definition/App.ts';
+import { require } from "./require.ts";
+
+const { App } = require('@rocket.chat/apps-engine/definition/App.js') as {
+    App: typeof _App;
+};
+
 const extensionCodec = new ExtensionCodec();
 
 extensionCodec.register({
     type: 0,
     encode: (object: unknown) => {
         // We don't care about functions, but also don't want to throw an error
-        if (typeof object === 'function') {
+        if (typeof object === 'function' || object instanceof App) {
             return new Uint8Array(0);
         }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
- Fix `providedApiEndpoints` - Deno was saving the api endpoints in an object, but the original property was an array

- Prevent App instances from being serialized by msgpack - To use certain features, such as slash commands or api enpoints, apps usually create a subclass of those that include a reference to the main app class; but serializing the app class can be difficult as several properties are not serializable. So now we prevent that from happening


# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
