### PR TITLE
Improve logs

### DIFF
--- a/deno-runtime/handlers/api-handler.ts
+++ b/deno-runtime/handlers/api-handler.ts
@@ -23,7 +23,7 @@ export default async function apiHandler(call: string, params: unknown): Promise
 
     const [request, endpointInfo] = params as Array<unknown>;
 
-    logger?.debug(`${path}'s ${method} is being executed...`, request);
+    logger?.debug(`${path}'s ${call} is being executed...`, request);
 
     try {
         // deno-lint-ignore ban-types
@@ -36,11 +36,11 @@ export default async function apiHandler(call: string, params: unknown): Promise
             AppAccessorsInstance.getPersistence(),
         ]);
 
-        logger?.debug(`${path}'s ${method} was successfully executed.`);
+        logger?.debug(`${path}'s ${call} was successfully executed.`);
 
         return result;
     } catch (e) {
-        logger?.debug(`${path}'s ${method} was unsuccessful.`);
+        logger?.debug(`${path}'s ${call} was unsuccessful.`);
         return new JsonRpcError(e.message, -32000);
     }
 }

--- a/deno-runtime/handlers/app/handler.ts
+++ b/deno-runtime/handlers/app/handler.ts
@@ -18,6 +18,11 @@ import { AppObjectRegistry } from '../../AppObjectRegistry.ts';
 export default async function handleApp(method: string, params: unknown): Promise<Defined | JsonRpcError> {
     const [, appMethod] = method.split(':');
 
+    // We don't want the getStatus method to generate logs, so we handle it separately
+    if (appMethod === 'getStatus') {
+        return handleGetStatus();
+    }
+
     // `app` will be undefined if the method here is "app:construct"
     const app = AppObjectRegistry.get<App>('app');
 
@@ -56,9 +61,6 @@ export default async function handleApp(method: string, params: unknown): Promis
                 break;
             case 'initialize':
                 result = await handleInitialize();
-                break;
-            case 'getStatus':
-                result = await handleGetStatus();
                 break;
             case 'setStatus':
                 result = await handleSetStatus(params);


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
- Prevent app:getStatus from generating logs - it was becoming difficult to see relevant logs
- Wrong variable was being logged in the API handler - it was logging a function's toString instead of the method from the request
- Add logs to slash command handler
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
