### PR TITLE
Remove unnecessary await in Node's message handler

### DIFF
--- a/src/server/runtime/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/AppsEngineDenoRuntime.ts
@@ -58,6 +58,7 @@ extensionCodec.register({
             return new Uint8Array(object.buffer, object.byteOffset, object.byteLength);
         }
     },
+    // By passing byteOffset and byteLength, we're creating a view of the original buffer instead of copying it
     decode: (data: Uint8Array) => Buffer.from(data.buffer, data.byteOffset, data.byteLength),
 });
 
@@ -421,12 +422,12 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
                 }
 
                 if (JSONRPCMessage.type === 'request' || JSONRPCMessage.type === 'notification') {
-                    await this.handleIncomingMessage(JSONRPCMessage);
+                    this.handleIncomingMessage(JSONRPCMessage).catch((reason) => console.error('Error executing handler', reason));
                     continue;
                 }
 
                 if (JSONRPCMessage.type === 'success' || JSONRPCMessage.type === 'error') {
-                    await this.handleResultMessage(JSONRPCMessage);
+                    this.handleResultMessage(JSONRPCMessage).catch((reason) => console.error('Error executing handler', reason));
                     continue;
                 }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
When we receive a message from Deno, we do not need to await the handler function. It ends up blocking the handling of any subsequent message, causing false timeouts.

We've already removed the await on the Deno side, the behavior should be the same on Node
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
