### PR TITLE
fix: remove buffer converter

### DIFF
--- a/deno-runtime/lib/accessors/mod.ts
+++ b/deno-runtime/lib/accessors/mod.ts
@@ -212,23 +212,7 @@ export class AppAccessors {
                 getUserReader: () => this.proxify('getReader:getUserReader'),
                 getNotifier: () => this.proxify('getReader:getNotifier'),
                 getLivechatReader: () => this.proxify('getReader:getLivechatReader'),
-                getUploadReader: () => ({
-                    _proxy: this.proxify('getReader:getUploadReader'),
-                    getById(id: string) {
-                        return this._proxy.getById(id);
-                    },
-                    // Convert the Uint8Array to a Buffer 
-                    async getBufferById(id: string) {
-                        const result = await this._proxy.getBufferById(id);
-                        return Buffer.from(result);
-                    },
-                    // Convert the Uint8Array to a Buffer 
-                    async getBuffer(upload: IUpload) {
-                        const result = await this._proxy.getBuffer(upload);
-                        return Buffer.from(result);
-                    },
-
-                }),
+                getUploadReader: () => this.proxify('getReader:getUploadReader'),
                 getCloudWorkspaceReader: () => this.proxify('getReader:getCloudWorkspaceReader'),
                 getVideoConferenceReader: () => this.proxify('getReader:getVideoConferenceReader'),
                 getOAuthAppsReader: () => this.proxify('getReader:getOAuthAppsReader'),

--- a/deno-runtime/lib/accessors/mod.ts
+++ b/deno-runtime/lib/accessors/mod.ts
@@ -9,7 +9,6 @@ import type { IPersistence } from '@rocket.chat/apps-engine/definition/accessors
 import type { IHttp } from '@rocket.chat/apps-engine/definition/accessors/IHttp.ts';
 import type { IConfigurationExtend } from '@rocket.chat/apps-engine/definition/accessors/IConfigurationExtend.ts';
 import type { ISlashCommand } from '@rocket.chat/apps-engine/definition/slashcommands/ISlashCommand.ts';
-import type { IUpload } from '@rocket.chat/apps-engine/definition/uploads/IUpload.ts';
 import type { IProcessor } from '@rocket.chat/apps-engine/definition/scheduler/IProcessor.ts';
 import type { IApi } from '@rocket.chat/apps-engine/definition/api/IApi.ts';
 import type { IVideoConfProvider } from '@rocket.chat/apps-engine/definition/videoConfProviders/IVideoConfProvider.ts';
@@ -19,7 +18,6 @@ import { AppObjectRegistry } from '../../AppObjectRegistry.ts';
 import { ModifyCreator } from './modify/ModifyCreator.ts';
 import { ModifyUpdater } from './modify/ModifyUpdater.ts';
 import { ModifyExtender } from './modify/ModifyExtender.ts';
-import { Buffer } from 'node:buffer';
 
 const httpMethods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const;
 

--- a/src/server/accessors/UploadCreator.ts
+++ b/src/server/accessors/UploadCreator.ts
@@ -8,21 +8,18 @@ export class UploadCreator implements IUploadCreator {
     constructor(private readonly bridges: AppBridges, private readonly appId: string) {}
 
     public async uploadBuffer(buffer: Buffer, descriptor: IUploadDescriptor): Promise<IUpload> {
-        // We need to convert to buffer since Deno sends Uint8Array
-        const buff = Buffer.from(buffer);
-
         if (!descriptor.hasOwnProperty('user') && !descriptor.visitorToken) {
             descriptor.user = await this.bridges.getUserBridge().doGetAppUser(this.appId);
         }
 
         const details = {
             name: descriptor.filename,
-            size: buff.length,
+            size: buffer.length,
             rid: descriptor.room.id,
             userId: descriptor.user?.id,
             visitorToken: descriptor.visitorToken,
         } as IUploadDetails;
 
-        return this.bridges.getUploadBridge().doCreateUpload(details, buff, this.appId);
+        return this.bridges.getUploadBridge().doCreateUpload(details, buffer, this.appId);
     }
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Remove buffer converters between apps.engine and app since the msgpack is already doing it.

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
[VM2-13](https://rocketchat.atlassian.net/browse/VM2-13)

# PS :eyes:


[VM2-13]: https://rocketchat.atlassian.net/browse/VM2-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ