### PR TITLE
Fix permissions for Deno subprocess when package is installed

### DIFF
--- a/deno-runtime/lib/accessors/mod.ts
+++ b/deno-runtime/lib/accessors/mod.ts
@@ -1,5 +1,5 @@
 import type { IAppAccessors } from '@rocket.chat/apps-engine/definition/accessors/IAppAccessors.ts';
-import { IApiEndpointMetadata } from '@rocket.chat/apps-engine/definition/api/IApiEndpointMetadata.ts';
+import type { IApiEndpointMetadata } from '@rocket.chat/apps-engine/definition/api/IApiEndpointMetadata.ts';
 import type { IEnvironmentWrite } from '@rocket.chat/apps-engine/definition/accessors/IEnvironmentWrite.ts';
 import type { IEnvironmentRead } from '@rocket.chat/apps-engine/definition/accessors/IEnvironmentRead.ts';
 import type { IConfigurationModify } from '@rocket.chat/apps-engine/definition/accessors/IConfigurationModify.ts';

--- a/src/server/runtime/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/AppsEngineDenoRuntime.ts
@@ -118,9 +118,13 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         try {
             const denoExePath = getDenoExecutablePath();
             const denoWrapperPath = getDenoWrapperPath();
-            const denoWrapperDir = path.dirname(path.join(denoWrapperPath, '..'));
+            // During development, the appsEngineDir is enough to run the deno process
+            const appsEngineDir = path.dirname(path.join(denoWrapperPath, '..'));
+            // When running in production, we're likely inside a node_modules which the Deno
+            // process must be able to read in order to include files that use NPM packages
+            const parentNodeModulesDir = path.dirname(path.join(appsEngineDir, '..'));
 
-            this.deno = child_process.spawn(denoExePath, ['run', `--allow-read=${denoWrapperDir}/`, denoWrapperPath, '--subprocess']);
+            this.deno = child_process.spawn(denoExePath, ['run', `--allow-read=${appsEngineDir}/,${parentNodeModulesDir}/`, denoWrapperPath, '--subprocess']);
 
             this.setupListeners();
         } catch {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
The modifications worked when we had the source code symlinked to Rocket.Chat. However, when it was installed via npm/yarn, the Deno subprocess would not start, because it lacked the permission to read the parent `node_modules` directory which contains packages used by the Apps-Engine.
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
