### PR TITLE
add Open prefix to find/count by agent methods

### DIFF
--- a/src/definition/accessors/ILivechatRead.ts
+++ b/src/definition/accessors/ILivechatRead.ts
@@ -17,8 +17,8 @@ export interface ILivechatRead {
     isOnlineAsync(departmentId?: string): Promise<boolean>;
     getDepartmentsEnabledWithAgents(): Promise<Array<IDepartment>>;
     getLivechatRooms(visitor: IVisitor, departmentId?: string): Promise<Array<ILivechatRoom>>;
-    getLivechatRoomsByAgentId(agentId: string): Promise<Array<ILivechatRoom>>;
-    getLivechatTotalRoomsByAgentId(agentId: string): Promise<number>;
+    getLivechatOpenRoomsByAgentId(agentId: string): Promise<Array<ILivechatRoom>>;
+    getLivechatTotalOpenRoomsByAgentId(agentId: string): Promise<number>;
     /**
      * @deprecated This method does not adhere to the conversion practices applied
      * elsewhere in the Apps-Engine and will be removed in the next major version.

--- a/src/server/accessors/LivechatRead.ts
+++ b/src/server/accessors/LivechatRead.ts
@@ -30,12 +30,12 @@ export class LivechatRead implements ILivechatRead {
         return this.livechatBridge.doFindRooms(visitor, departmentId, this.appId);
     }
 
-    public getLivechatTotalRoomsByAgentId(agentId: string): Promise<number> {
-        return this.livechatBridge.doCountRoomsByAgentId(agentId, this.appId);
+    public getLivechatTotalOpenRoomsByAgentId(agentId: string): Promise<number> {
+        return this.livechatBridge.doCountOpenRoomsByAgentId(agentId, this.appId);
     }
 
-    public getLivechatRoomsByAgentId(agentId: string): Promise<Array<ILivechatRoom>> {
-        return this.livechatBridge.doFindRoomsByAgentId(agentId, this.appId);
+    public getLivechatOpenRoomsByAgentId(agentId: string): Promise<Array<ILivechatRoom>> {
+        return this.livechatBridge.doFindOpenRoomsByAgentId(agentId, this.appId);
     }
 
     /**

--- a/src/server/bridges/LivechatBridge.ts
+++ b/src/server/bridges/LivechatBridge.ts
@@ -104,15 +104,15 @@ export abstract class LivechatBridge extends BaseBridge {
         }
     }
 
-    public async doCountRoomsByAgentId(agentId: string, appId: string): Promise<number> {
+    public async doCountOpenRoomsByAgentId(agentId: string, appId: string): Promise<number> {
         if (this.hasReadPermission(appId, 'livechat-room')) {
-            return this.countRoomsByAgentId(agentId, appId);
+            return this.countOpenRoomsByAgentId(agentId, appId);
         }
     }
 
-    public async doFindRoomsByAgentId(agentId: string, appId: string): Promise<Array<ILivechatRoom>> {
+    public async doFindOpenRoomsByAgentId(agentId: string, appId: string): Promise<Array<ILivechatRoom>> {
         if (this.hasReadPermission(appId, 'livechat-room')) {
-            return this.findRoomsByAgentId(agentId, appId);
+            return this.findOpenRoomsByAgentId(agentId, appId);
         }
     }
 
@@ -183,9 +183,9 @@ export abstract class LivechatBridge extends BaseBridge {
 
     protected abstract closeRoom(room: ILivechatRoom, comment: string, closer: IUser | undefined, appId: string): Promise<boolean>;
 
-    protected abstract countRoomsByAgentId(agentId: string, appId: string): Promise<number>;
+    protected abstract countOpenRoomsByAgentId(agentId: string, appId: string): Promise<number>;
 
-    protected abstract findRoomsByAgentId(agentId: string, appId: string): Promise<Array<ILivechatRoom>>;
+    protected abstract findOpenRoomsByAgentId(agentId: string, appId: string): Promise<Array<ILivechatRoom>>;
 
     protected abstract findRooms(visitor: IVisitor, departmentId: string | null, appId: string): Promise<Array<ILivechatRoom>>;
 

--- a/tests/test-data/bridges/livechatBridge.ts
+++ b/tests/test-data/bridges/livechatBridge.ts
@@ -70,11 +70,11 @@ export class TestLivechatBridge extends LivechatBridge {
         throw new Error('Method not implemented');
     }
 
-    public findRoomsByAgentId(agentId: string, appId: string): Promise<ILivechatRoom[]> {
+    public findOpenRoomsByAgentId(agentId: string, appId: string): Promise<ILivechatRoom[]> {
         throw new Error('Method not implemented');
     }
 
-    public countRoomsByAgentId(agentId: string, appId: string): Promise<number> {
+    public countOpenRoomsByAgentId(agentId: string, appId: string): Promise<number> {
         throw new Error('Method not implemented');
     }
 


### PR DESCRIPTION
# What? :boat:

- add `open` prefix to find/count by AgentId methods

# Why? :thinking:

- make clear the scope of the methods

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
