### PR TITLE
fix: fix the url import usage on oauth2

### DIFF
--- a/src/definition/oauth2/IOAuth2.ts
+++ b/src/definition/oauth2/IOAuth2.ts
@@ -1,3 +1,5 @@
+import type { URL } from 'url';
+
 import type { IConfigurationExtend, IHttp, IModify, IPersistence, IRead } from '../accessors';
 import type { IUser } from '../users/IUser';
 

--- a/src/server/oauth2/OAuth2Client.ts
+++ b/src/server/oauth2/OAuth2Client.ts
@@ -1,3 +1,5 @@
+import { URL } from 'url';
+
 import type { IConfigurationExtend, IHttp, IModify, IPersistence, IRead } from '../../definition/accessors';
 import { HttpStatusCode } from '../../definition/accessors';
 import type { IApiEndpointInfo, IApiRequest, IApiResponse } from '../../definition/api';


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

Fix the import of URL interface

# Why? :thinking:
<!--Additional explanation if needed-->

It is affecting apps that uses the OAuth2 bridge

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
[CORE-187](https://rocketchat.atlassian.net/browse/CORE-187)
# PS :eyes:


[CORE-187]: https://rocketchat.atlassian.net/browse/CORE-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ