### PR TITLE
Bundle legacy apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -703,6 +703,144 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@esbuild/aix-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "optional": true
+        },
+        "@esbuild/android-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "optional": true
+        },
+        "@esbuild/android-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "optional": true
+        },
+        "@esbuild/android-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "optional": true
+        },
+        "@esbuild/darwin-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "optional": true
+        },
+        "@esbuild/linux-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "optional": true
+        },
+        "@esbuild/linux-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "optional": true
+        },
+        "@esbuild/linux-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "optional": true
+        },
+        "@esbuild/linux-s390x": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "optional": true
+        },
+        "@esbuild/linux-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+            "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+            "optional": true
+        },
+        "@esbuild/sunos-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+            "optional": true
+        },
+        "@esbuild/win32-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "optional": true
+        },
+        "@esbuild/win32-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "optional": true
+        },
+        "@esbuild/win32-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "optional": true
+        },
         "@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -4039,6 +4177,36 @@
                     "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
                     "dev": true
                 }
+            }
+        },
+        "esbuild": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "requires": {
+                "@esbuild/aix-ppc64": "0.20.2",
+                "@esbuild/android-arm": "0.20.2",
+                "@esbuild/android-arm64": "0.20.2",
+                "@esbuild/android-x64": "0.20.2",
+                "@esbuild/darwin-arm64": "0.20.2",
+                "@esbuild/darwin-x64": "0.20.2",
+                "@esbuild/freebsd-arm64": "0.20.2",
+                "@esbuild/freebsd-x64": "0.20.2",
+                "@esbuild/linux-arm": "0.20.2",
+                "@esbuild/linux-arm64": "0.20.2",
+                "@esbuild/linux-ia32": "0.20.2",
+                "@esbuild/linux-loong64": "0.20.2",
+                "@esbuild/linux-mips64el": "0.20.2",
+                "@esbuild/linux-ppc64": "0.20.2",
+                "@esbuild/linux-riscv64": "0.20.2",
+                "@esbuild/linux-s390x": "0.20.2",
+                "@esbuild/linux-x64": "0.20.2",
+                "@esbuild/netbsd-x64": "0.20.2",
+                "@esbuild/openbsd-x64": "0.20.2",
+                "@esbuild/sunos-x64": "0.20.2",
+                "@esbuild/win32-arm64": "0.20.2",
+                "@esbuild/win32-ia32": "0.20.2",
+                "@esbuild/win32-x64": "0.20.2"
             }
         },
         "escalade": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
         "adm-zip": "^0.5.9",
         "cryptiles": "^4.1.3",
         "deno-bin": "1.37.1",
+        "esbuild": "^0.20.2",
         "jose": "^4.11.1",
         "jsonrpc-lite": "^2.2.0",
         "lodash.clonedeep": "^4.5.0",

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -35,7 +35,7 @@ import { AppLogStorage, AppMetadataStorage } from './storage';
 import { AppSourceStorage } from './storage/AppSourceStorage';
 import { AppInstallationSource } from './storage/IAppStorageItem';
 import { AppRuntimeManager } from './managers/AppRuntimeManager';
-import type { DenoRuntimeSubprocessController } from './runtime/AppsEngineDenoRuntime';
+import type { DenoRuntimeSubprocessController } from './runtime/deno/AppsEngineDenoRuntime';
 
 export interface IAppInstallParameters {
     enable: boolean;

--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -6,7 +6,7 @@ import type { AppManager } from './AppManager';
 import { InvalidInstallationError } from './errors/InvalidInstallationError';
 import { AppConsole } from './logging';
 import { AppLicenseValidationResult } from './marketplace/license';
-import type { DenoRuntimeSubprocessController } from './runtime/AppsEngineDenoRuntime';
+import type { DenoRuntimeSubprocessController } from './runtime/deno/AppsEngineDenoRuntime';
 import type { AppsEngineRuntime } from './runtime/AppsEngineRuntime';
 import type { IAppStorageItem } from './storage';
 

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -30,7 +30,7 @@ import type { AppManager } from '../AppManager';
 import type { ProxiedApp } from '../ProxiedApp';
 import type { AppAccessorManager } from './AppAccessorManager';
 import { Utilities } from '../misc/Utilities';
-import { JSONRPC_METHOD_NOT_FOUND } from '../runtime/AppsEngineDenoRuntime';
+import { JSONRPC_METHOD_NOT_FOUND } from '../runtime/deno/AppsEngineDenoRuntime';
 
 interface IListenerExecutor {
     [AppInterface.IPreMessageSentPrevent]: {

--- a/src/server/managers/AppRuntimeManager.ts
+++ b/src/server/managers/AppRuntimeManager.ts
@@ -1,6 +1,6 @@
 import type { AppManager } from '../AppManager';
 import type { IParseAppPackageResult } from '../compiler';
-import { DenoRuntimeSubprocessController } from '../runtime/AppsEngineDenoRuntime';
+import { DenoRuntimeSubprocessController } from '../runtime/deno/AppsEngineDenoRuntime';
 
 export type AppRuntimeParams = {
     appId: string;

--- a/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -59,7 +59,7 @@ export function getDenoWrapperPath(): string {
         return require.resolve('../../deno-runtime/main.ts');
     } catch {
         // This path is relative to the original Apps-Engine files
-        return require.resolve('../../../deno-runtime/main.ts');
+        return require.resolve('../../../../deno-runtime/main.ts');
     }
 }
 
@@ -114,8 +114,9 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
             ]);
 
             this.setupListeners();
-        } catch {
+        } catch (e) {
             this.state = 'invalid';
+            console.error('Failed to start Deno subprocess', e);
         }
 
         this.accessors = manager.getAccessorManager();

--- a/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -3,16 +3,16 @@ import * as path from 'path';
 import { type Readable, EventEmitter } from 'stream';
 
 import * as jsonrpc from 'jsonrpc-lite';
-import { Decoder, Encoder, ExtensionCodec } from '@msgpack/msgpack';
 
-import type { AppManager } from '../AppManager';
-import type { AppLogStorage } from '../storage';
-import type { AppBridges } from '../bridges';
-import type { IParseAppPackageResult } from '../compiler';
-import type { AppAccessorManager, AppApiManager } from '../managers';
-import type { ILoggerStorageEntry } from '../logging';
-import type { AppRuntimeManager } from '../managers/AppRuntimeManager';
-import { AppStatus } from '../../definition/AppStatus';
+import { encoder, decoder } from './codec';
+import type { AppManager } from '../../AppManager';
+import type { AppLogStorage } from '../../storage';
+import type { AppBridges } from '../../bridges';
+import type { IParseAppPackageResult } from '../../compiler';
+import type { AppAccessorManager, AppApiManager } from '../../managers';
+import type { ILoggerStorageEntry } from '../../logging';
+import type { AppRuntimeManager } from '../../managers/AppRuntimeManager';
+import { AppStatus } from '../../../definition/AppStatus';
 
 export const ALLOWED_ACCESSOR_METHODS = [
     'getConfigurationExtend',
@@ -36,34 +36,6 @@ export const ALLOWED_ACCESSOR_METHODS = [
         | 'getModifier'
     >
 >;
-
-const extensionCodec = new ExtensionCodec();
-
-extensionCodec.register({
-    type: 0,
-    encode: (object: unknown) => {
-        // We don't care about functions, but also don't want to throw an error
-        if (typeof object === 'function') {
-            return new Uint8Array([0]);
-        }
-    },
-    decode: (_data: Uint8Array) => undefined,
-});
-
-// We need to handle Buffers because Deno needs its own decoding
-extensionCodec.register({
-    type: 1,
-    encode: (object: unknown) => {
-        if (object instanceof Buffer) {
-            return new Uint8Array(object.buffer, object.byteOffset, object.byteLength);
-        }
-    },
-    // By passing byteOffset and byteLength, we're creating a view of the original buffer instead of copying it
-    decode: (data: Uint8Array) => Buffer.from(data.buffer, data.byteOffset, data.byteLength),
-});
-
-const encoder = new Encoder({ extensionCodec });
-const decoder = new Decoder({ extensionCodec });
 
 export const JSONRPC_METHOD_NOT_FOUND = -32601;
 

--- a/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -13,6 +13,7 @@ import type { AppAccessorManager, AppApiManager } from '../../managers';
 import type { ILoggerStorageEntry } from '../../logging';
 import type { AppRuntimeManager } from '../../managers/AppRuntimeManager';
 import { AppStatus } from '../../../definition/AppStatus';
+import { bundleLegacyApp } from './bundler';
 
 export const ALLOWED_ACCESSOR_METHODS = [
     'getConfigurationExtend',
@@ -148,6 +149,11 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
     }
 
     public async setupApp() {
+        // If there is more than one file in the package, then it is a legacy app that has not been bundled
+        if (Object.keys(this.appPackage.files).length > 1) {
+            await bundleLegacyApp(this.appPackage);
+        }
+
         await this.waitUntilReady();
 
         await this.sendRequest({ method: 'app:construct', params: [this.appPackage] });

--- a/src/server/runtime/deno/bundler.ts
+++ b/src/server/runtime/deno/bundler.ts
@@ -1,7 +1,14 @@
-import { build } from 'esbuild';
+import * as path from 'path';
 
-import { IParseAppPackageResult } from '../../compiler';
+import { build, type PluginBuild, type OnLoadArgs, type OnResolveArgs } from 'esbuild';
 
+import type { IParseAppPackageResult } from '../../compiler';
+
+/**
+ * Some legacy apps that might be installed in workspaces have not been bundled after compilation,
+ * leading to multiple files being sent to the subprocess and requiring further logic to require one another.
+ * This makes running the app in the Deno Runtime much more difficult, so instead we bundle the files at runtime.
+ */
 export async function bundleLegacyApp(appPackage: IParseAppPackageResult) {
     const buildResult = await build({
         write: false,
@@ -18,5 +25,66 @@ export async function bundleLegacyApp(appPackage: IParseAppPackageResult) {
             sourcefile: appPackage.info.classFile,
             loader: 'js',
         },
+        plugins: [
+            {
+                name: 'legacy-app',
+                setup(build: PluginBuild) {
+                    build.onResolve({ filter: /.*/ }, (args: OnResolveArgs) => {
+                        if (args.namespace === 'file') {
+                            return;
+                        }
+
+                        const modulePath = path.join(path.dirname(args.importer), args.path).concat('.js');
+
+                        const hasFile = !!appPackage.files[modulePath];
+
+                        if (hasFile) {
+                            return {
+                                namespace: 'app-source',
+                                path: modulePath,
+                            };
+                        }
+
+                        // require('../') or require('./') are both valid, but aren't included in the files record in the same way
+                        // we need to treat those differently
+                        if (/\.\.?\//.test(args.path)) {
+                            const indexModulePath = modulePath.replace(/\.js$/, `${path.sep}index.js`);
+
+                            if (appPackage.files[indexModulePath]) {
+                                return {
+                                    namespace: 'app-source',
+                                    path: indexModulePath,
+                                };
+                            }
+                        }
+
+                        return {
+                            path: args.path,
+                            external: true,
+                        };
+                    });
+
+                    build.onLoad({ filter: /.*/, namespace: 'app-source' }, (args: OnLoadArgs) => {
+                        if (!appPackage.files[args.path]) {
+                            return {
+                                errors: [
+                                    {
+                                        text: `File ${args.path} could not be found`,
+                                    },
+                                ],
+                            };
+                        }
+
+                        return {
+                            contents: appPackage.files[args.path],
+                        };
+                    });
+                },
+            },
+        ],
     });
+
+    const [{ text: bundle }] = buildResult.outputFiles;
+
+    appPackage.files = { [appPackage.info.classFile]: bundle };
 }

--- a/src/server/runtime/deno/bundler.ts
+++ b/src/server/runtime/deno/bundler.ts
@@ -1,0 +1,22 @@
+import { build } from 'esbuild';
+
+import { IParseAppPackageResult } from '../../compiler';
+
+export async function bundleLegacyApp(appPackage: IParseAppPackageResult) {
+    const buildResult = await build({
+        write: false,
+        bundle: true,
+        minify: true,
+        platform: 'node',
+        target: ['node10'],
+        define: {
+            'global.Promise': 'Promise',
+        },
+        external: ['@rocket.chat/apps-engine/*'],
+        stdin: {
+            contents: appPackage.files[appPackage.info.classFile],
+            sourcefile: appPackage.info.classFile,
+            loader: 'js',
+        },
+    });
+}

--- a/src/server/runtime/deno/codec.ts
+++ b/src/server/runtime/deno/codec.ts
@@ -1,0 +1,29 @@
+import { Decoder, Encoder, ExtensionCodec } from '@msgpack/msgpack';
+
+const extensionCodec = new ExtensionCodec();
+
+extensionCodec.register({
+    type: 0,
+    encode: (object: unknown) => {
+        // We don't care about functions, but also don't want to throw an error
+        if (typeof object === 'function') {
+            return new Uint8Array([0]);
+        }
+    },
+    decode: (_data: Uint8Array) => undefined,
+});
+
+// We need to handle Buffers because Deno needs its own decoding
+extensionCodec.register({
+    type: 1,
+    encode: (object: unknown) => {
+        if (object instanceof Buffer) {
+            return new Uint8Array(object.buffer, object.byteOffset, object.byteLength);
+        }
+    },
+    // By passing byteOffset and byteLength, we're creating a view of the original buffer instead of copying it
+    decode: (data: Uint8Array) => Buffer.from(data.buffer, data.byteOffset, data.byteLength),
+});
+
+export const encoder = new Encoder({ extensionCodec });
+export const decoder = new Decoder({ extensionCodec });

--- a/tests/server/compiler/AppFabricationFulfillment.spec.ts
+++ b/tests/server/compiler/AppFabricationFulfillment.spec.ts
@@ -7,7 +7,7 @@ import type { AppManager } from '../../../src/server/AppManager';
 import { AppFabricationFulfillment } from '../../../src/server/compiler';
 import { ProxiedApp } from '../../../src/server/ProxiedApp';
 import type { IAppStorageItem } from '../../../src/server/storage';
-import type { DenoRuntimeSubprocessController } from '../../../src/server/runtime/AppsEngineDenoRuntime';
+import type { DenoRuntimeSubprocessController } from '../../../src/server/runtime/deno/AppsEngineDenoRuntime';
 
 export class AppFabricationFulfillmentTestFixture {
     @Test()

--- a/tests/server/managers/AppApiManager.spec.ts
+++ b/tests/server/managers/AppApiManager.spec.ts
@@ -19,7 +19,7 @@ import type { AppLogStorage } from '../../../src/server/storage';
 import { TestsAppBridges } from '../../test-data/bridges/appBridges';
 import { TestsAppLogStorage } from '../../test-data/storage/logStorage';
 import { TestData } from '../../test-data/utilities';
-import type { DenoRuntimeSubprocessController } from '../../../src/server/runtime/AppsEngineDenoRuntime';
+import type { DenoRuntimeSubprocessController } from '../../../src/server/runtime/deno/AppsEngineDenoRuntime';
 
 export class AppApiManagerTestFixture {
     public static doThrow = false;

--- a/tests/server/managers/AppSlashCommandManager.spec.ts
+++ b/tests/server/managers/AppSlashCommandManager.spec.ts
@@ -20,7 +20,7 @@ import type { ProxiedApp } from '../../../src/server/ProxiedApp';
 import { Room } from '../../../src/server/rooms/Room';
 import type { AppsEngineRuntime } from '../../../src/server/runtime/AppsEngineRuntime';
 import type { AppLogStorage } from '../../../src/server/storage';
-import type { DenoRuntimeSubprocessController } from '../../../src/server/runtime/AppsEngineDenoRuntime';
+import type { DenoRuntimeSubprocessController } from '../../../src/server/runtime/deno/AppsEngineDenoRuntime';
 
 export class AppSlashCommandManagerTestFixture {
     public static doThrow = false;

--- a/tests/server/runtime/DenoRuntimeSubprocessController.spec.ts
+++ b/tests/server/runtime/DenoRuntimeSubprocessController.spec.ts
@@ -5,7 +5,7 @@ import { TestFixture, Setup, Expect, AsyncTest, SpyOn, Any, AsyncSetupFixture, T
 
 import { AppAccessorManager, AppApiManager } from '../../../src/server/managers';
 import { TestInfastructureSetup } from '../../test-data/utilities';
-import { DenoRuntimeSubprocessController } from '../../../src/server/runtime/AppsEngineDenoRuntime';
+import { DenoRuntimeSubprocessController } from '../../../src/server/runtime/deno/AppsEngineDenoRuntime';
 import type { AppManager } from '../../../src/server/AppManager';
 import { UserStatusConnection, UserType } from '../../../src/definition/users';
 import type { IParseAppPackageResult } from '../../../src/server/compiler';

--- a/tests/test-data/utilities.ts
+++ b/tests/test-data/utilities.ts
@@ -33,7 +33,7 @@ import type {
     AppVideoConfProviderManager,
 } from '../../src/server/managers';
 import type { UIActionButtonManager } from '../../src/server/managers/UIActionButtonManager';
-import type { DenoRuntimeSubprocessController } from '../../src/server/runtime/AppsEngineDenoRuntime';
+import type { DenoRuntimeSubprocessController } from '../../src/server/runtime/deno/AppsEngineDenoRuntime';
 import { AppPackageParser } from '../../src/server/compiler';
 import type { AppRuntimeManager } from '../../src/server/managers/AppRuntimeManager';
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
- Move the AppsEngineDenoRuntime to its own folder
- Call bundler before sending construct command to subprocess
# Why? :thinking:
<!--Additional explanation if needed-->
Legacy apps were not bundled during packaging, but this structure makes dealing with the package much harder on the Deno subprocess.

So now we bundle apps that need it before sending the package to the subprocess.
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
We couldn't use the bundler from the @rocket.chat/apps-compiler package due to the different expectations it deals with, so we just adapted the code to this specific case