### PR TITLE
fix: handle api endpoint execution exceptions

### DIFF
--- a/deno-runtime/handlers/api-handler.ts
+++ b/deno-runtime/handlers/api-handler.ts
@@ -41,6 +41,7 @@ export default async function apiHandler(call: string, params: unknown): Promise
         return result;
     } catch (e) {
         logger?.debug(`${path}'s ${call} was unsuccessful.`);
-        return new JsonRpcError(e.message, -32000);
+        logger?.error(e);
+        return { status: 500, content: 'Internal server error.'}
     }
 }

--- a/deno-runtime/handlers/api-handler.ts
+++ b/deno-runtime/handlers/api-handler.ts
@@ -41,7 +41,6 @@ export default async function apiHandler(call: string, params: unknown): Promise
         return result;
     } catch (e) {
         logger?.debug(`${path}'s ${call} was unsuccessful.`);
-        logger?.error(e);
-        return { status: 500, content: 'Internal server error.'}
+        return new JsonRpcError(e.message || "Internal server error", -32000);
     }
 }

--- a/deno-runtime/handlers/tests/api-handler.test.ts
+++ b/deno-runtime/handlers/tests/api-handler.test.ts
@@ -70,10 +70,7 @@ describe('handlers > api', () => {
     it('correctly handles an error if the method execution fails', async () => {
         const result = await apiHandler(`api:/test:put`, ['request', 'endpointInfo']);
 
-        assertInstanceOf(result, JsonRpcError)
-        assertObjectMatch(result, {
-            message: `Method execution error example`,
-            code: -32000
-        })
+        assertInstanceOf(result, Object)
+        assertObjectMatch(result, { status: 500, content: 'Internal server error.'})
     });
 });

--- a/deno-runtime/handlers/tests/api-handler.test.ts
+++ b/deno-runtime/handlers/tests/api-handler.test.ts
@@ -70,7 +70,10 @@ describe('handlers > api', () => {
     it('correctly handles an error if the method execution fails', async () => {
         const result = await apiHandler(`api:/test:put`, ['request', 'endpointInfo']);
 
-        assertInstanceOf(result, Object)
-        assertObjectMatch(result, { status: 500, content: 'Internal server error.'})
+        assertInstanceOf(result, JsonRpcError)
+        assertObjectMatch(result, {
+            message: `Method execution error example`,
+            code: -32000
+        })
     });
 });

--- a/tests/server/runtime/DenoRuntimeSubprocessController.spec.ts
+++ b/tests/server/runtime/DenoRuntimeSubprocessController.spec.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 
 import { TestFixture, Setup, Expect, AsyncTest, SpyOn, Any, AsyncSetupFixture, Teardown } from 'alsatian';
+import type { SuccessObject } from 'jsonrpc-lite';
 
 import { AppAccessorManager, AppApiManager } from '../../../src/server/managers';
 import { TestInfastructureSetup } from '../../test-data/utilities';
@@ -198,7 +199,7 @@ export class DenuRuntimeSubprocessControllerTestFixture {
         };
 
         // eslint-disable-next-line
-        const { id, result } = await this.controller['handleBridgeMessage']({
+        const response = await this.controller['handleBridgeMessage']({
             type: 'request' as any,
             payload: {
                 jsonrpc: '2.0',
@@ -208,6 +209,7 @@ export class DenuRuntimeSubprocessControllerTestFixture {
                 serialize: () => '',
             },
         });
+        const { id, result } = response as SuccessObject;
 
         Expect(this.manager.getBridges().getMessageBridge().doCreate).toHaveBeenCalledWith(messageParam, '9c1d62ca-e40f-456f-8601-17c823a16c68');
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
The fix should solve problems where Rocket.chat throws an exception when executing the endpoint, but the application doesn't catch it. We return an ' Internal server error ' to avoid letting the client of the request go without a response.

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
