### PR TITLE
feat: Implement the Apps Engine Room message read bridge

### DIFF
--- a/src/definition/accessors/IRoomRead.ts
+++ b/src/definition/accessors/IRoomRead.ts
@@ -45,7 +45,7 @@ export interface IRoomRead {
      * @param roomId the room's id
      * @returns an iterator for messages
      */
-    getMessages(roomId: string): Promise<IterableIterator<IMessage>>;
+    getMessages(roomId: string): Promise<IMessage[]>;
 
     /**
      * Gets an iterator for all of the users in the provided room.

--- a/src/definition/accessors/IRoomRead.ts
+++ b/src/definition/accessors/IRoomRead.ts
@@ -40,12 +40,23 @@ export interface IRoomRead {
     getCreatorUserByName(name: string): Promise<IUser | undefined>;
 
     /**
-     * Gets an iterator for all of the messages in the provided room.
+     * Retrieves an array of messages from the specified room.
      *
-     * @param roomId the room's id
-     * @returns an iterator for messages
+     * @param roomId The unique identifier of the room from which to retrieve messages.
+     * @param options Optional parameters for retrieving messages:
+     *                - limit: The maximum number of messages to retrieve. If more than 100 is passed, it defaults to 100.
+     *                - skip: The number of messages to skip (for pagination).
+     *                - sort: An object defining the sorting order of the messages. Each key is a field to sort by, and the value is either 1 for ascending order or -1 for descending order.
+     * @returns A Promise that resolves to an array of IMessage objects representing the messages in the room.
      */
-    getMessages(roomId: string): Promise<IMessage[]>;
+    getMessages(
+        roomId: string,
+        options?: Partial<{
+            limit: number;
+            skip: number;
+            sort: Record<string, 1 | -1>;
+        }>,
+    ): Promise<IMessage[]>;
 
     /**
      * Gets an iterator for all of the users in the provided room.

--- a/src/server/accessors/RoomRead.ts
+++ b/src/server/accessors/RoomRead.ts
@@ -23,8 +23,8 @@ export class RoomRead implements IRoomRead {
         return this.roomBridge.doGetCreatorByName(name, this.appId);
     }
 
-    public getMessages(roomId: string): Promise<IterableIterator<IMessage>> {
-        throw new Error('Method not implemented.');
+    public getMessages(roomId: string): Promise<Array<IMessage>> {
+        return this.roomBridge.doGetMessages(roomId, this.appId);
     }
 
     public getMembers(roomId: string): Promise<Array<IUser>> {

--- a/src/server/accessors/RoomRead.ts
+++ b/src/server/accessors/RoomRead.ts
@@ -23,8 +23,15 @@ export class RoomRead implements IRoomRead {
         return this.roomBridge.doGetCreatorByName(name, this.appId);
     }
 
-    public getMessages(roomId: string): Promise<Array<IMessage>> {
-        return this.roomBridge.doGetMessages(roomId, this.appId);
+    public getMessages(
+        roomId: string,
+        options?: Partial<{
+            limit: number;
+            skip: number;
+            sort: Record<string, 1 | -1>;
+        }>,
+    ): Promise<IMessage[]> {
+        return this.roomBridge.doGetMessages(roomId, this.appId, options);
     }
 
     public getMembers(roomId: string): Promise<Array<IUser>> {

--- a/src/server/accessors/RoomRead.ts
+++ b/src/server/accessors/RoomRead.ts
@@ -31,7 +31,7 @@ export class RoomRead implements IRoomRead {
             sort: Record<string, 1 | -1>;
         }>,
     ): Promise<IMessage[]> {
-        return this.roomBridge.doGetMessages(roomId, this.appId, options);
+        return this.roomBridge.doGetMessages(roomId, { limit: 100, ...options }, this.appId);
     }
 
     public getMembers(roomId: string): Promise<Array<IUser>> {

--- a/src/server/bridges/RoomBridge.ts
+++ b/src/server/bridges/RoomBridge.ts
@@ -91,6 +91,12 @@ export abstract class RoomBridge extends BaseBridge {
         }
     }
 
+    public async doGetMessages(roomId: string, appId: string): Promise<Array<IMessage>> {
+        if (this.hasReadPermission(appId)) {
+            return this.getMessages(roomId, appId);
+        }
+    }
+
     protected abstract create(room: IRoom, members: Array<string>, appId: string): Promise<string>;
 
     protected abstract getById(roomId: string, appId: string): Promise<IRoom>;
@@ -122,6 +128,8 @@ export abstract class RoomBridge extends BaseBridge {
     protected abstract getOwners(roomId: string, appId: string): Promise<Array<IUser>>;
 
     protected abstract getLeaders(roomId: string, appId: string): Promise<Array<IUser>>;
+
+    protected abstract getMessages(roomId: string, appId: string): Promise<Array<IMessage>>;
 
     private hasWritePermission(appId: string): boolean {
         if (AppPermissionManager.hasPermission(appId, AppPermissions.room.write)) {

--- a/src/server/bridges/RoomBridge.ts
+++ b/src/server/bridges/RoomBridge.ts
@@ -93,15 +93,15 @@ export abstract class RoomBridge extends BaseBridge {
 
     public async doGetMessages(
         roomId: string,
-        appId: string,
-        options?: Partial<{
+        options: {
             limit: number;
-            skip: number;
-            sort: Record<string, 1 | -1>;
-        }>,
+            skip?: number;
+            sort?: Record<string, 1 | -1>;
+        },
+        appId: string,
     ): Promise<IMessage[]> {
         if (this.hasReadPermission(appId)) {
-            return this.getMessages(roomId, appId, options);
+            return this.getMessages(roomId, options, appId);
         }
     }
 
@@ -139,12 +139,12 @@ export abstract class RoomBridge extends BaseBridge {
 
     protected abstract getMessages(
         roomId: string,
-        appId: string,
-        options?: Partial<{
+        options: {
             limit: number;
-            skip: number;
-            sort: Record<string, 1 | -1>;
-        }>,
+            skip?: number;
+            sort?: Record<string, 1 | -1>;
+        },
+        appId: string,
     ): Promise<IMessage[]>;
 
     private hasWritePermission(appId: string): boolean {

--- a/src/server/bridges/RoomBridge.ts
+++ b/src/server/bridges/RoomBridge.ts
@@ -91,9 +91,17 @@ export abstract class RoomBridge extends BaseBridge {
         }
     }
 
-    public async doGetMessages(roomId: string, appId: string): Promise<Array<IMessage>> {
+    public async doGetMessages(
+        roomId: string,
+        appId: string,
+        options?: Partial<{
+            limit: number;
+            skip: number;
+            sort: Record<string, 1 | -1>;
+        }>,
+    ): Promise<IMessage[]> {
         if (this.hasReadPermission(appId)) {
-            return this.getMessages(roomId, appId);
+            return this.getMessages(roomId, appId, options);
         }
     }
 
@@ -129,7 +137,15 @@ export abstract class RoomBridge extends BaseBridge {
 
     protected abstract getLeaders(roomId: string, appId: string): Promise<Array<IUser>>;
 
-    protected abstract getMessages(roomId: string, appId: string): Promise<Array<IMessage>>;
+    protected abstract getMessages(
+        roomId: string,
+        appId: string,
+        options?: Partial<{
+            limit: number;
+            skip: number;
+            sort: Record<string, 1 | -1>;
+        }>,
+    ): Promise<IMessage[]>;
 
     private hasWritePermission(appId: string): boolean {
         if (AppPermissionManager.hasPermission(appId, AppPermissions.room.write)) {

--- a/tests/server/accessors/RoomRead.spec.ts
+++ b/tests/server/accessors/RoomRead.spec.ts
@@ -5,11 +5,14 @@ import type { IUser } from '../../../src/definition/users';
 import { RoomRead } from '../../../src/server/accessors';
 import type { RoomBridge } from '../../../src/server/bridges';
 import { TestData } from '../../test-data/utilities';
+import type { IMessage } from '../../../src/definition/messages';
 
 export class RoomReadAccessorTestFixture {
     private room: IRoom;
 
     private user: IUser;
+
+    private messages: IMessage[];
 
     private mockRoomBridgeWithRoom: RoomBridge;
 
@@ -17,9 +20,11 @@ export class RoomReadAccessorTestFixture {
     public setupFixture() {
         this.room = TestData.getRoom();
         this.user = TestData.getUser();
+        this.messages = ['507f1f77bcf86cd799439011', '507f191e810c19729de860ea'].map((id) => TestData.getMessage(id));
 
         const theRoom = this.room;
         const theUser = this.user;
+        const theMessages = this.messages;
         this.mockRoomBridgeWithRoom = {
             doGetById(id, appId): Promise<IRoom> {
                 return Promise.resolve(theRoom);
@@ -38,6 +43,9 @@ export class RoomReadAccessorTestFixture {
             },
             doGetMembers(name, appId): Promise<Array<IUser>> {
                 return Promise.resolve([theUser]);
+            },
+            doGetMessages(roomId, appId, options): Promise<IMessage[]> {
+                return Promise.resolve(theMessages);
             },
         } as RoomBridge;
     }
@@ -58,6 +66,8 @@ export class RoomReadAccessorTestFixture {
         Expect(await rr.getCreatorUserByName('testing')).toBe(this.user);
         Expect(await rr.getDirectByUsernames([this.user.username])).toBeDefined();
         Expect(await rr.getDirectByUsernames([this.user.username])).toBe(this.room);
+        Expect(await rr.getMessages('testing')).toBeDefined();
+        Expect(await rr.getMessages('testing')).toBe(this.messages);
     }
 
     @AsyncTest()
@@ -65,7 +75,6 @@ export class RoomReadAccessorTestFixture {
         Expect(() => new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app')).not.toThrow();
 
         const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
-        await Expect(() => rr.getMessages('faker')).toThrowErrorAsync(Error, 'Method not implemented.');
 
         Expect(await rr.getMembers('testing')).toBeDefined();
         Expect((await rr.getMembers('testing')) as Array<IUser>).not.toBeEmpty();

--- a/tests/test-data/bridges/roomBridge.ts
+++ b/tests/test-data/bridges/roomBridge.ts
@@ -32,6 +32,10 @@ export class TestsRoomBridge extends RoomBridge {
         throw new Error('Method not implemented.');
     }
 
+    public getMessages(roomId: string, appId: string, options?: Partial<{ limit: number; skip: number; sort: Record<string, 1 | -1> }>): Promise<IMessage[]> {
+        throw new Error('Method not implemented.');
+    }
+
     public update(room: IRoom, members: Array<string>, appId: string): Promise<void> {
         throw new Error('Method not implemented.');
     }

--- a/tests/test-data/bridges/roomBridge.ts
+++ b/tests/test-data/bridges/roomBridge.ts
@@ -32,7 +32,7 @@ export class TestsRoomBridge extends RoomBridge {
         throw new Error('Method not implemented.');
     }
 
-    public getMessages(roomId: string, appId: string, options?: Partial<{ limit: number; skip: number; sort: Record<string, 1 | -1> }>): Promise<IMessage[]> {
+    public getMessages(roomId: string, options: { limit: number; skip?: number; sort?: Record<string, 1 | -1> }, appId: string): Promise<IMessage[]> {
         throw new Error('Method not implemented.');
     }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
- Updated the Room bridge's `getMessages` method to return the messages in a batch
# Why? :thinking:
<!--Additional explanation if needed-->

- Previously, the `getMessages` method was available, but when using and making the call, there was an error `Method not implemented`, which caused confusion as well as provided no other way to fetch room messages
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
- [ADR](https://adr.rocket.chat/0063)
- [Rocket.Chat Bridge PR](https://github.com/RocketChat/Rocket.Chat/pull/32176)

# PS :eyes:
