### PR TITLE
Improve ping time

### DIFF
--- a/deno-runtime/lib/messenger.ts
+++ b/deno-runtime/lib/messenger.ts
@@ -29,6 +29,8 @@ export function isErrorResponse(message: jsonrpc.JsonRpc): message is jsonrpc.Er
     return message instanceof jsonrpc.ErrorObject;
 }
 
+const COMMAND_PONG = '_zPONG';
+
 export const RPCResponseObserver = new EventTarget();
 
 export const Queue = new (class Queue {
@@ -53,7 +55,7 @@ export const Queue = new (class Queue {
         this.isProcessing = false;
     }
 
-    public enqueue(message: jsonrpc.JsonRpc) {
+    public enqueue(message: jsonrpc.JsonRpc | typeof COMMAND_PONG) {
         this.queue.push(encoder.encode(message));
         this.processQueue();
     }
@@ -155,6 +157,10 @@ export async function successResponse({ id, result }: SuccessResponseDescriptor)
     const rpc = jsonrpc.success(id, payload);
 
     await Queue.enqueue(rpc);
+}
+
+export function pongResponse(): Promise<void> {
+    return Promise.resolve(Queue.enqueue(COMMAND_PONG));
 }
 
 export async function sendRequest(requestDescriptor: RequestDescriptor): Promise<jsonrpc.SuccessObject> {

--- a/deno-runtime/main.ts
+++ b/deno-runtime/main.ts
@@ -118,7 +118,7 @@ async function main() {
             }
         } catch (error) {
             if (Messenger.isErrorResponse(error)) {
-                await Messenger.Transport.send(error);
+                await Messenger.errorResponse(error);
             } else {
                 await Messenger.sendParseError();
             }

--- a/deno-runtime/main.ts
+++ b/deno-runtime/main.ts
@@ -31,6 +31,8 @@ type Handlers = {
     ping: (method: string, params: unknown) => 'pong';
 };
 
+const COMMAND_PING = '_zPING';
+
 async function requestRouter({ type, payload }: Messenger.JsonRpcRequest): Promise<void> {
     const methodHandlers: Handlers = {
         app: handleApp,
@@ -98,6 +100,12 @@ async function main() {
 
     for await (const message of decoder.decodeStream(Deno.stdin.readable)) {
         try {
+            // Process PING command first as it is not JSON RPC
+            if (message === COMMAND_PING) {
+                Messenger.pongResponse();
+                continue;
+            }
+
             const JSONRPCMessage = Messenger.parseMessage(message as Record<string, unknown>);
 
             if (Messenger.isRequest(JSONRPCMessage)) {


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Make the ping/pong mechanism use simple strings instead of a full JSON RPC message.
# Why? :thinking:
<!--Additional explanation if needed-->
This saves some CPU cycles by avoiding the creation of an object and also its encoding by msgpack. Pings now always take less than 1ms for the whole roundtrip
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
