### PR TITLE
Allow Deno process to read NODE_EXTRA_CA_CERTS env var

### DIFF
--- a/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -41,6 +41,12 @@ export const ALLOWED_ACCESSOR_METHODS = [
     >
 >;
 
+// Trying to access environment variables in Deno throws an error where in vm2 it simply returned `undefined`
+// So here we define the allowed envvars to prevent the process (and the compatibility) from breaking
+export const ALLOWED_ENVIRONMENT_VARIABLES = [
+    'NODE_EXTRA_CA_CERTS', // Accessed by the `https` node module
+];
+
 const COMMAND_PING = '_zPING';
 const COMMAND_PONG = '_zPONG';
 
@@ -119,6 +125,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
                 'run',
                 hasNetworkingPermission ? '--allow-net' : '',
                 `--allow-read=${appsEngineDir},${parentNodeModulesDir}`,
+                `--allow-env=${ALLOWED_ENVIRONMENT_VARIABLES.join(',')}`,
                 denoWrapperPath,
                 '--subprocess',
             ];
@@ -126,7 +133,6 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
             this.debug('Starting Deno subprocess for app with options %O', options);
 
             this.deno = child_process.spawn(denoExePath, options, { env: null });
-            // console.log(this.deno);
 
             this.setupListeners();
             this.startPing();


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Title explains it.
# Why? :thinking:
<!--Additional explanation if needed-->
With vm2 there was no error when an app tried to access an environment variable, it simply returned `undefined` for all of them. But Deno throws an error when that happens, and this breaks compatibility with some apps. That's why we're trying to prevent it.
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
