### PR TITLE
fix: Add new `AppMethodNotFound` error to allow handling of missing app methods

### DIFF
--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -7,6 +7,7 @@ import type { IAppAuthorInfo, IAppInfo } from '../definition/metadata';
 import { AppMethod } from '../definition/metadata';
 import type { AppManager } from './AppManager';
 import { NotEnoughMethodArgumentsError } from './errors';
+import { AppMethodNotFound } from './errors/AppMethodNotFound';
 import { InvalidInstallationError } from './errors/InvalidInstallationError';
 import { AppConsole } from './logging';
 import { AppLicenseValidationResult } from './marketplace/license';
@@ -65,7 +66,7 @@ export class ProxiedApp implements IApp {
 
     public async call(method: `${AppMethod}`, ...args: Array<any>): Promise<any> {
         if (typeof (this.app as any)[method] !== 'function') {
-            throw new Error(`The App ${this.app.getName()} (${this.app.getID()} does not have the method: "${method}"`);
+            throw new AppMethodNotFound(`The App ${this.app.getName()} (${this.app.getID()} does not have the method: "${method}"`);
         }
 
         const methodDeclartion = (this.app as any)[method] as (...args: any[]) => any;

--- a/src/server/errors/AppMethodNotFound.ts
+++ b/src/server/errors/AppMethodNotFound.ts
@@ -1,0 +1,9 @@
+export class AppMethodNotFound implements Error {
+    public name = 'AppMethodNotFound';
+
+    public message: string;
+
+    constructor(message: string) {
+        this.message = message;
+    }
+}

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -1053,8 +1053,10 @@ export class AppListenerManager {
 
         const app = this.manager.getOneById(appId);
         if (!app?.hasMethod(method)) {
-            console.warn(`App ${appId} triggered an interaction but it doen't exist or doesn't have method ${method}`);
-            return;
+            if (method !== 'executeViewClosedHandler') {
+                console.warn(`App ${appId} triggered an interaction but it doen't exist or doesn't have method ${method}`);
+                return;
+            }
         }
 
         const { actionId, user, triggerId } = data;


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

# Why? :thinking:
<!--Additional explanation if needed-->
There was an issue with some apps that didn't implement `executeViewCloseHandler`. This causes opened modals to be open forever on UI. This is because when the UI attempts to close it, it calls the aforementioned handler, and since it didn't exist, apps engine errored out.

This returned an empty response to the UI, which ignored the response and continued to show the view.
# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
https://rocketchat.atlassian.net/browse/CORE-401
# PS :eyes:
