### PR TITLE
fix: Add default behavior to `executeViewCloseHandler` for all apps that don't implement it

### DIFF
--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -239,6 +239,8 @@ export class AppListenerManager {
 
     private listeners: Map<string, Array<string>>;
 
+    private defaultHandlers = new Map<string, any>();
+
     /**
      * Locked events are those who are listed in an app's
      * "essentials" list but the app is disabled.
@@ -256,6 +258,8 @@ export class AppListenerManager {
             this.listeners.set(intt, []);
             this.lockedEvents.set(intt, new Set<string>());
         });
+
+        this.defaultHandlers.set('executeViewClosedHandler', { success: true });
     }
 
     public registerListeners(app: ProxiedApp): void {
@@ -1052,7 +1056,12 @@ export class AppListenerManager {
 
         const app = this.manager.getOneById(appId);
         if (!app?.hasMethod(method)) {
-            console.warn(`App ${appId} triggered an interaction but it doen't exist or doesn't have method ${method}`);
+            if (this.defaultHandlers.has(method)) {
+                console.warn(`App ${appId} triggered an interaction but it doesn't exist or doesn't have method ${method}. Falling back to default handler.`);
+                return this.defaultHandlers.get(method);
+            }
+
+            console.warn(`App ${appId} triggered an interaction but it doen't exist or doesn't have method ${method} and default handler doesn't exist.`);
             return;
         }
 

--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -1061,7 +1061,7 @@ export class AppListenerManager {
                 return this.defaultHandlers.get(method);
             }
 
-            console.warn(`App ${appId} triggered an interaction but it doen't exist or doesn't have method ${method} and default handler doesn't exist.`);
+            console.warn(`App ${appId} triggered an interaction but it doesn't exist or doesn't have method ${method} and there is no default handler for it.`);
             return;
         }
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

# Why? :thinking:
<!--Additional explanation if needed-->
There was an issue with some apps that didn't implement executeViewCloseHandler. This causes opened modals to be open forever on UI. This is because when the UI attempts to close it, it calls the aforementioned handler, and since it didn't exist, apps engine errored out.

This returned an empty response to the UI, which ignored the response and continued to show the view.


# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
[rocketchat.atlassian.net/browse/CORE-401](https://rocketchat.atlassian.net/browse/CORE-401)
# PS :eyes:
