### PR TITLE
feat(deno-runtime): limit timeout of "Pre" listener events to 1s

### DIFF
--- a/src/server/ProxiedApp.ts
+++ b/src/server/ProxiedApp.ts
@@ -49,9 +49,17 @@ export class ProxiedApp {
         return logger;
     }
 
+    // We'll need to refactor this method to remove the rest parameters so we can pass an options parameter
     public async call(method: `${AppMethod}`, ...args: Array<any>): Promise<any> {
+        let options;
+
+        // Pre events need to be fast as they block the user
+        if (method.startsWith('checkPre') || method.startsWith('executePre')) {
+            options = { timeout: 1000 };
+        }
+
         try {
-            return await this.appRuntime.sendRequest({ method: `app:${method}`, params: args });
+            return await this.appRuntime.sendRequest({ method: `app:${method}`, params: args }, options);
         } catch (e) {
             if (e.code === AppsEngineException.JSONRPC_ERROR_CODE) {
                 throw new AppsEngineException(e.message);


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Add an option to the runtime request functions to allow for ad-hoc overriting of the default timeout configuration (10s)

# Why? :thinking:
<!--Additional explanation if needed-->
Long time outs on "Pre" listener events were causing actions on the RocketChat side to take too long if a subprocess became faulty

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
The API ended up being a bit off due to the current architecture constrains of the `ProxiedApp`. We'll need to reevaluate at a later date.