### PR TITLE
feat(deno-runtime): restart app process if it times out consecutively

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -484,9 +484,9 @@ export class AppManager {
         app.getStorageItem().marketplaceInfo = storageItem.marketplaceInfo;
         await app.validateLicense().catch();
 
+        storageItem.status = await app.getStatus();
         // This is async, but we don't care since it only updates in the database
         // and it should not mutate any properties we care about
-        storageItem.status = await app.getStatus();
         await this.appMetadataStorage.update(storageItem).catch();
 
         return true;
@@ -549,7 +549,7 @@ export class AppManager {
         // the App instance from the source.
         const app = await this.getCompiler().toSandBox(this, descriptor, result);
 
-        undoSteps.push(() => app.getDenoRuntime().stopApp());
+        undoSteps.push(() => this.getRuntime().stopRuntime(app.getDenoRuntime()));
 
         // Create a user for the app
         try {
@@ -641,7 +641,7 @@ export class AppManager {
         await this.appMetadataStorage.remove(app.getID());
         await this.appSourceStorage.remove(app.getStorageItem()).catch();
 
-        app.getDenoRuntime().stopApp();
+        this.getRuntime().stopRuntime(app.getDenoRuntime());
 
         this.apps.delete(app.getID());
     }
@@ -687,7 +687,7 @@ export class AppManager {
         descriptor.signature = await this.signatureManager.signApp(descriptor);
         const stored = await this.appMetadataStorage.update(descriptor);
 
-        this.apps.get(old.id).getDenoRuntime().stopApp();
+        this.getRuntime().stopRuntime(this.apps.get(old.id).getDenoRuntime());
 
         const app = await this.getCompiler().toSandBox(this, descriptor, result);
 
@@ -731,7 +731,7 @@ export class AppManager {
             if (appPackageOrInstance instanceof Buffer) {
                 const parseResult = await this.getParser().unpackageApp(appPackageOrInstance);
 
-                this.apps.get(stored.id).getDenoRuntime().stopApp();
+                this.getRuntime().stopRuntime(this.apps.get(stored.id).getDenoRuntime());
 
                 return this.getCompiler().toSandBox(this, stored, parseResult);
             }

--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -641,7 +641,7 @@ export class AppManager {
         await this.appMetadataStorage.remove(app.getID());
         await this.appSourceStorage.remove(app.getStorageItem()).catch();
 
-        this.getRuntime().stopRuntime(app.getDenoRuntime());
+        await this.getRuntime().stopRuntime(app.getDenoRuntime());
 
         this.apps.delete(app.getID());
     }
@@ -687,7 +687,7 @@ export class AppManager {
         descriptor.signature = await this.signatureManager.signApp(descriptor);
         const stored = await this.appMetadataStorage.update(descriptor);
 
-        this.getRuntime().stopRuntime(this.apps.get(old.id).getDenoRuntime());
+        await this.getRuntime().stopRuntime(this.apps.get(old.id).getDenoRuntime());
 
         const app = await this.getCompiler().toSandBox(this, descriptor, result);
 
@@ -731,7 +731,7 @@ export class AppManager {
             if (appPackageOrInstance instanceof Buffer) {
                 const parseResult = await this.getParser().unpackageApp(appPackageOrInstance);
 
-                this.getRuntime().stopRuntime(this.apps.get(stored.id).getDenoRuntime());
+                await this.getRuntime().stopRuntime(this.apps.get(stored.id).getDenoRuntime());
 
                 return this.getCompiler().toSandBox(this, stored, parseResult);
             }

--- a/src/server/managers/AppRuntimeManager.ts
+++ b/src/server/managers/AppRuntimeManager.ts
@@ -45,8 +45,8 @@ export class AppRuntimeManager {
         return subprocess.sendRequest(execRequest);
     }
 
-    public stopRuntime(controller: DenoRuntimeSubprocessController): void {
-        controller.stopApp();
+    public async stopRuntime(controller: DenoRuntimeSubprocessController): Promise<void> {
+        await controller.stopApp();
 
         const appId = controller.getAppId();
 

--- a/src/server/managers/AppRuntimeManager.ts
+++ b/src/server/managers/AppRuntimeManager.ts
@@ -45,8 +45,10 @@ export class AppRuntimeManager {
         return subprocess.sendRequest(execRequest);
     }
 
-    public stopRuntime(runtime: DenoRuntimeSubprocessController): void {
-        const appId = runtime.getAppId();
+    public stopRuntime(controller: DenoRuntimeSubprocessController): void {
+        controller.stopApp();
+
+        const appId = controller.getAppId();
 
         if (appId in this.subprocesses) {
             delete this.subprocesses[appId];

--- a/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -176,6 +176,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         }
 
         delete this.deno;
+        this.messenger.clearReceiver();
     }
 
     // Debug purposes, could be deleted later

--- a/src/server/runtime/deno/LivenessManager.ts
+++ b/src/server/runtime/deno/LivenessManager.ts
@@ -1,0 +1,161 @@
+import type { ChildProcess } from 'child_process';
+import { EventEmitter } from 'stream';
+
+import type { DenoRuntimeSubprocessController } from './AppsEngineDenoRuntime';
+import type { ProcessMessenger } from './ProcessMessenger';
+
+const COMMAND_PING = '_zPING';
+
+const defaultOptions: LivenessManager['options'] = {
+    pingRequestTimeout: 10000,
+    pingFrequencyInMS: 10000,
+    consecutiveTimeoutLimit: 4,
+    maxRestarts: 3,
+};
+
+/**
+ * Responsible for pinging the Deno subprocess and for restarting it
+ * if something doesn't look right
+ */
+export class LivenessManager {
+    private readonly controller: DenoRuntimeSubprocessController;
+
+    private readonly messenger: ProcessMessenger;
+
+    private readonly debug: debug.Debugger;
+
+    private readonly options: {
+        // How long should we wait for a response to the ping request
+        pingRequestTimeout: number;
+
+        // How long is the delay between ping messages
+        pingFrequencyInMS: number;
+
+        // Limit of times the process can timeout the ping response before we consider it as unresponsive
+        consecutiveTimeoutLimit: number;
+
+        // Limit of times we can try to restart a process
+        maxRestarts: number;
+    };
+
+    private subprocess: ChildProcess;
+
+    // This is the perfect use-case for an AbortController, but it's experimental in Node 14.x
+    private pingAbortController: EventEmitter;
+
+    private pingTimeoutConsecutiveCount = 0;
+
+    private restartCount = 0;
+
+    private restartLog: Record<string, unknown>[] = [];
+
+    constructor(
+        deps: {
+            controller: DenoRuntimeSubprocessController;
+            messenger: ProcessMessenger;
+            debug: debug.Debugger;
+        },
+        options: Partial<LivenessManager['options']> = {},
+    ) {
+        this.controller = deps.controller;
+        this.messenger = deps.messenger;
+        this.debug = deps.debug;
+        this.pingAbortController = new EventEmitter();
+
+        this.options = Object.assign({}, defaultOptions, options);
+    }
+
+    public attach(deno: ChildProcess) {
+        this.subprocess = deno;
+
+        this.pingTimeoutConsecutiveCount = 0;
+
+        this.controller.once('ready', this.ping.bind(this));
+        this.subprocess.once('exit', this.handleExit.bind(this));
+    }
+
+    /**
+     * Start up the process of ping/pong for liveness check
+     *
+     * The message exchange does not use JSON RPC as it adds a lot of overhead
+     * with the creation and encoding of a full object for transfer. By using a
+     * string the process is less intensive.
+     */
+    private ping() {
+        const start = Date.now();
+
+        const responsePromise = new Promise<void>((resolve, reject) => {
+            const onceCallback = () => {
+                this.debug('Ping successful in %d ms', Date.now() - start);
+                clearTimeout(timeoutId);
+                this.pingTimeoutConsecutiveCount = 0;
+                resolve();
+            };
+
+            const abortCallback = () => {
+                this.debug('Ping aborted');
+                clearTimeout(timeoutId);
+                this.controller.off('pong', onceCallback);
+                reject();
+            };
+
+            const timeoutCallback = () => {
+                this.debug('Ping failed in %d ms (consecutive failure #%d)', Date.now() - start, this.pingTimeoutConsecutiveCount);
+                this.controller.off('pong', onceCallback);
+                this.pingAbortController.off('abort', abortCallback);
+                this.pingTimeoutConsecutiveCount++;
+                reject();
+            };
+
+            const timeoutId = setTimeout(timeoutCallback, this.options.pingRequestTimeout);
+
+            this.controller.once('pong', onceCallback);
+            this.pingAbortController.once('abort', abortCallback);
+        }).catch(() => {});
+
+        this.messenger.send(COMMAND_PING);
+
+        responsePromise.finally(() => {
+            if (this.pingTimeoutConsecutiveCount >= this.options.consecutiveTimeoutLimit) {
+                this.debug('Subprocess failed to respond to pings %d consecutive times. Attempting restart...', this.options.consecutiveTimeoutLimit);
+                this.restartProcess();
+                return;
+            }
+
+            setTimeout(this.ping.bind(this), this.options.pingFrequencyInMS);
+        });
+    }
+
+    private handleExit(exitCode: number, signal: string) {
+        const processState = this.controller.getProcessState();
+        // If the we're restarting the process, or want to stop the process, or it exited cleanly, nothing else for us to do
+        if (processState === 'restarting' || processState === 'stopped' || (exitCode === 0 && !signal)) {
+            return;
+        }
+
+        // Otherwise we try to restart the subprocess, if possible
+        this.debug('App has been killed (%s). Attempting restart #%d...', signal, this.restartCount + 1);
+
+        this.pingAbortController.emit('abort');
+
+        this.restartProcess();
+    }
+
+    private restartProcess() {
+        if (this.restartCount >= this.options.maxRestarts) {
+            this.debug('Limit of restarts reached (%d). Aborting restart...', this.options.maxRestarts);
+            this.controller.stopApp();
+            return;
+        }
+
+        this.pingTimeoutConsecutiveCount = 0;
+        this.restartCount++;
+        this.restartLog.push({
+            restartedAt: new Date(),
+            source: 'liveness-manager',
+            pid: this.subprocess.pid,
+        });
+
+        this.controller.restartApp();
+    }
+}

--- a/src/server/runtime/deno/ProcessMessenger.ts
+++ b/src/server/runtime/deno/ProcessMessenger.ts
@@ -1,0 +1,42 @@
+import { ChildProcess } from 'child_process';
+
+import type { JsonRpc } from 'jsonrpc-lite';
+
+import { encoder } from './codec';
+
+export class ProcessMessenger {
+    private deno: ChildProcess;
+
+    private _sendStrategy: (message: JsonRpc) => void;
+
+    constructor(private readonly debug: debug.Debugger) {
+        this._sendStrategy = this.strategyError;
+    }
+
+    public get send() {
+        return this._sendStrategy.bind(this);
+    }
+
+    public setReceiver(deno: ChildProcess) {
+        this.deno = deno;
+
+        this.switchStrategy();
+    }
+
+    private switchStrategy() {
+        if (this.deno instanceof ChildProcess) {
+            this._sendStrategy = this.strategySend.bind(this);
+        } else {
+            this._sendStrategy = this.strategyError.bind(this);
+        }
+    }
+
+    private strategyError(_message: JsonRpc) {
+        throw new Error('No process configured to receive a message');
+    }
+
+    private strategySend(message: JsonRpc) {
+        this.debug('Sending message to subprocess %o', message);
+        this.deno.stdin.write(encoder.encode(message));
+    }
+}

--- a/src/server/runtime/deno/ProcessMessenger.ts
+++ b/src/server/runtime/deno/ProcessMessenger.ts
@@ -23,6 +23,12 @@ export class ProcessMessenger {
         this.switchStrategy();
     }
 
+    public clearReceiver() {
+        delete this.deno;
+
+        this.switchStrategy();
+    }
+
     private switchStrategy() {
         if (this.deno instanceof ChildProcess) {
             this._sendStrategy = this.strategySend.bind(this);

--- a/tests/server/runtime/DenoRuntimeSubprocessController.spec.ts
+++ b/tests/server/runtime/DenoRuntimeSubprocessController.spec.ts
@@ -40,6 +40,7 @@ export class DenuRuntimeSubprocessControllerTestFixture {
     @Setup
     public setup() {
         this.controller = new DenoRuntimeSubprocessController(this.manager, this.appPackage);
+        this.controller.setupApp();
     }
 
     @Teardown


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Extracted two new components from the `DenoRuntimeSubprocessController` class:
- ProcessMessenger - controls transport of messages to the subprocess
- LivenessManager - controls the ping processes and restarts

Refactor the ping functionality to add the following:
- Keep track of consecutive ping timeouts. If reaches limit (currently 4), tries to restart the subprocess
- Keep track of restarts. If reaches limit (currently 3), stops restarting and leaves app in "broken" state
- Pings will now be aborted if the process exits (either due to a Deno error or a kill)
- Pings will now only start after the process is ready.

# Why? :thinking:
<!--Additional explanation if needed-->
If the Deno subprocess goes to an invalid state and stop responding, we try to restart it in hopes that this recovers the process nicely.

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
