### PR TITLE
fix: handler errors no being sent to subprocess

### DIFF
--- a/deno-runtime/lib/accessors/mod.ts
+++ b/deno-runtime/lib/accessors/mod.ts
@@ -71,7 +71,7 @@ export class AppAccessors {
                                 params,
                             })
                                 .then((response) => response.result)
-                                .catch((err) => err.error);
+                                .catch((err) => { throw new Error(err.error) });
                         },
                 },
             ) as T;

--- a/deno-runtime/lib/accessors/modify/ModifyCreator.ts
+++ b/deno-runtime/lib/accessors/modify/ModifyCreator.ts
@@ -34,7 +34,7 @@ const { RocketChatAssociationModel } = require('@rocket.chat/apps-engine/definit
 };
 
 export class ModifyCreator implements IModifyCreator {
-    constructor(private readonly senderFn: typeof Messenger.sendRequest) {}
+    constructor(private readonly senderFn: typeof Messenger.sendRequest) { }
 
     getLivechatCreator(): ILivechatCreator {
         return new Proxy(
@@ -56,7 +56,9 @@ export class ModifyCreator implements IModifyCreator {
                             params,
                         })
                             .then((response) => response.result)
-                            .catch((err) => err.error);
+                            .catch((err) => {
+                                throw new Error(err.error);
+                            });
                 },
             },
         ) as ILivechatCreator;
@@ -68,15 +70,17 @@ export class ModifyCreator implements IModifyCreator {
             {
                 get:
                     (_target: unknown, prop: string) =>
-                    (...params: unknown[]) =>
-                        prop === 'toJSON'
-                            ? {}
-                            : this.senderFn({
-                                  method: `accessor:getModifier:getCreator:getUploadCreator:${prop}`,
-                                  params,
-                              })
-                                  .then((response) => response.result)
-                                  .catch((err) => err.error),
+                        (...params: unknown[]) =>
+                            prop === 'toJSON'
+                                ? {}
+                                : this.senderFn({
+                                    method: `accessor:getModifier:getCreator:getUploadCreator:${prop}`,
+                                    params,
+                                })
+                                    .then((response) => response.result)
+                                    .catch((err) => {
+                                        throw new Error(err.error);
+                                    }),
             },
         ) as IUploadCreator;
     }

--- a/deno-runtime/lib/accessors/modify/ModifyUpdater.ts
+++ b/deno-runtime/lib/accessors/modify/ModifyUpdater.ts
@@ -26,7 +26,7 @@ const { RocketChatAssociationModel } = require('@rocket.chat/apps-engine/definit
 };
 
 export class ModifyUpdater implements IModifyUpdater {
-    constructor(private readonly senderFn: typeof Messenger.sendRequest) {}
+    constructor(private readonly senderFn: typeof Messenger.sendRequest) { }
 
     public getLivechatUpdater(): ILivechatUpdater {
         return new Proxy(
@@ -34,15 +34,17 @@ export class ModifyUpdater implements IModifyUpdater {
             {
                 get:
                     (_target: unknown, prop: string) =>
-                    (...params: unknown[]) =>
-                        prop === 'toJSON'
-                            ? {}
-                            : this.senderFn({
-                                  method: `accessor:getModifier:getUpdater:getLivechatUpdater:${prop}`,
-                                  params,
-                              })
-                                  .then((response) => response.result)
-                                  .catch((err) => err.error),
+                        (...params: unknown[]) =>
+                            prop === 'toJSON'
+                                ? {}
+                                : this.senderFn({
+                                    method: `accessor:getModifier:getUpdater:getLivechatUpdater:${prop}`,
+                                    params,
+                                })
+                                    .then((response) => response.result)
+                                    .catch((err) => {
+                                        throw new Error(err.error);
+                                    }),
             },
         ) as ILivechatUpdater;
     }
@@ -53,15 +55,17 @@ export class ModifyUpdater implements IModifyUpdater {
             {
                 get:
                     (_target: unknown, prop: string) =>
-                    (...params: unknown[]) =>
-                        prop === 'toJSON'
-                            ? {}
-                            : this.senderFn({
-                                  method: `accessor:getModifier:getUpdater:getUserUpdater:${prop}`,
-                                  params,
-                              })
-                                  .then((response) => response.result)
-                                  .catch((err) => err.error),
+                        (...params: unknown[]) =>
+                            prop === 'toJSON'
+                                ? {}
+                                : this.senderFn({
+                                    method: `accessor:getModifier:getUpdater:getUserUpdater:${prop}`,
+                                    params,
+                                })
+                                    .then((response) => response.result)
+                                    .catch((err) => {
+                                        throw new Error(err.error);
+                                    }),
             },
         ) as IUserUpdater;
     }

--- a/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -455,7 +455,13 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         const { method } = message.payload;
 
         if (method.startsWith('accessor:')) {
-            const result = await this.handleAccessorMessage(message as jsonrpc.IParsedObjectRequest);
+            let result: jsonrpc.SuccessObject | jsonrpc.ErrorObject;
+
+            try {
+                result = await this.handleAccessorMessage(message as jsonrpc.IParsedObjectRequest);
+            } catch (e) {
+                result = jsonrpc.error((message.payload as jsonrpc.RequestObject).id, new jsonrpc.JsonRpcError(e.message, 1000));
+            }
 
             this.messenger.send(result);
 
@@ -463,7 +469,13 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
         }
 
         if (method.startsWith('bridges:')) {
-            const result = await this.handleBridgeMessage(message as jsonrpc.IParsedObjectRequest);
+            let result: jsonrpc.SuccessObject | jsonrpc.ErrorObject;
+
+            try {
+                result = await this.handleBridgeMessage(message as jsonrpc.IParsedObjectRequest);
+            } catch (e) {
+                result = jsonrpc.error((message.payload as jsonrpc.RequestObject).id, new jsonrpc.JsonRpcError(e.message, 1000));
+            }
 
             this.messenger.send(result);
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Catch errors that happen during the execution of subprocess' requests in `DenoRuntimeSubprocessController` and send a proper JSON RPC error response to the subprocess.

These errors were not being sent over and the subprocess just waited indefinitely for a response.
# Why? :thinking:
<!--Additional explanation if needed-->
Apps should be able to handle exceptions that happen when something goes wrong with their calls

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
