### PR TITLE
fix: optional methods in video conf providers not being handled correctly

### DIFF
--- a/deno-runtime/handlers/tests/videoconference-handler.test.ts
+++ b/deno-runtime/handlers/tests/videoconference-handler.test.ts
@@ -100,11 +100,8 @@ describe('handlers > videoconference', () => {
 
         assertInstanceOf(result, JsonRpcError);
         assertObjectMatch(result, {
-            message: 'Method not found',
-            code: -32601,
-            data: {
-                message: `Provider ${providerName} not found`,
-            },
+            message: `Provider ${providerName} not found`,
+            code: -32000,
         });
     });
 

--- a/deno-runtime/handlers/tests/videoconference-handler.test.ts
+++ b/deno-runtime/handlers/tests/videoconference-handler.test.ts
@@ -1,12 +1,12 @@
 // deno-lint-ignore-file no-explicit-any
 import { assertEquals, assertObjectMatch } from 'https://deno.land/std@0.203.0/assert/mod.ts';
 import { beforeEach, describe, it } from 'https://deno.land/std@0.203.0/testing/bdd.ts';
-import { spy } from "https://deno.land/std@0.203.0/testing/mock.ts";
+import { spy } from 'https://deno.land/std@0.203.0/testing/mock.ts';
 
 import { AppObjectRegistry } from '../../AppObjectRegistry.ts';
 import videoconfHandler from '../videoconference-handler.ts';
-import { assertInstanceOf } from "https://deno.land/std@0.203.0/assert/assert_instance_of.ts";
-import { JsonRpcError } from "jsonrpc-lite";
+import { assertInstanceOf } from 'https://deno.land/std@0.203.0/assert/assert_instance_of.ts';
+import { JsonRpcError } from 'jsonrpc-lite';
 
 describe('handlers > videoconference', () => {
     // deno-lint-ignore no-unused-vars
@@ -16,15 +16,18 @@ describe('handlers > videoconference', () => {
     // deno-lint-ignore no-unused-vars
     const mockMethodWithTwoParam = (call: any, user: any, read: any, modify: any, http: any, persis: any): Promise<string> => Promise.resolve('ok two');
     // deno-lint-ignore no-unused-vars
-    const mockMethodWithThreeParam = (call: any, user: any, options: any, read: any, modify: any, http: any, persis: any): Promise<string> => Promise.resolve('ok three');
+    const mockMethodWithThreeParam = (call: any, user: any, options: any, read: any, modify: any, http: any, persis: any): Promise<string> =>
+        Promise.resolve('ok three');
     const mockProvider = {
         empty: mockMethodWithoutParam,
         one: mockMethodWithOneParam,
         two: mockMethodWithTwoParam,
         three: mockMethodWithThreeParam,
         notAFunction: true,
-        error: () => { throw new Error('Method execution error example') }
-    }
+        error: () => {
+            throw new Error('Method execution error example');
+        },
+    };
 
     beforeEach(() => {
         AppObjectRegistry.clear();
@@ -36,9 +39,9 @@ describe('handlers > videoconference', () => {
 
         const result = await videoconfHandler('videoconference:test-provider:empty', []);
 
-        assertEquals(result, 'ok none')
+        assertEquals(result, 'ok none');
         assertEquals(_spy.calls[0].args.length, 4);
-        
+
         _spy.restore();
     });
 
@@ -47,7 +50,7 @@ describe('handlers > videoconference', () => {
 
         const result = await videoconfHandler('videoconference:test-provider:one', ['call']);
 
-        assertEquals(result, 'ok one')
+        assertEquals(result, 'ok one');
         assertEquals(_spy.calls[0].args.length, 5);
         assertEquals(_spy.calls[0].args[0], 'call');
 
@@ -59,7 +62,7 @@ describe('handlers > videoconference', () => {
 
         const result = await videoconfHandler('videoconference:test-provider:two', ['call', 'user']);
 
-        assertEquals(result, 'ok two')
+        assertEquals(result, 'ok two');
         assertEquals(_spy.calls[0].args.length, 6);
         assertEquals(_spy.calls[0].args[0], 'call');
         assertEquals(_spy.calls[0].args[1], 'user');
@@ -72,7 +75,7 @@ describe('handlers > videoconference', () => {
 
         const result = await videoconfHandler('videoconference:test-provider:three', ['call', 'user', 'options']);
 
-        assertEquals(result, 'ok three')
+        assertEquals(result, 'ok three');
         assertEquals(_spy.calls[0].args.length, 7);
         assertEquals(_spy.calls[0].args[0], 'call');
         assertEquals(_spy.calls[0].args[1], 'user');
@@ -84,34 +87,39 @@ describe('handlers > videoconference', () => {
     it('correctly handles an error on execution of a videoconf method', async () => {
         const result = await videoconfHandler('videoconference:test-provider:error', []);
 
-        assertInstanceOf(result, JsonRpcError)
+        assertInstanceOf(result, JsonRpcError);
         assertObjectMatch(result, {
             message: 'Method execution error example',
-            code: -32000
-        })
-    })
+            code: -32000,
+        });
+    });
 
     it('correctly handles an error when provider is not found', async () => {
-        const providerName = 'error-provider'
+        const providerName = 'error-provider';
         const result = await videoconfHandler(`videoconference:${providerName}:method`, []);
 
-        assertInstanceOf(result, JsonRpcError)
+        assertInstanceOf(result, JsonRpcError);
         assertObjectMatch(result, {
-            message: `Provider ${providerName} not found`,
-            code: -32000
-        })
-    })
+            message: 'Method not found',
+            code: -32601,
+            data: {
+                message: `Provider ${providerName} not found`,
+            },
+        });
+    });
 
     it('correctly handles an error if method is not a function of provider', async () => {
-        const methodName = 'notAFunction'
-        const providerName = 'test-provider'
+        const methodName = 'notAFunction';
+        const providerName = 'test-provider';
         const result = await videoconfHandler(`videoconference:${providerName}:${methodName}`, []);
 
-        assertInstanceOf(result, JsonRpcError)
+        assertInstanceOf(result, JsonRpcError);
         assertObjectMatch(result, {
-            message: `Method ${methodName} not found on provider ${providerName}`,
-            code: -32000
-        })
-    })
-    
+            message: 'Method not found',
+            code: -32601,
+            data: {
+                message: `Method ${methodName} not found on provider ${providerName}`,
+            },
+        });
+    });
 });

--- a/deno-runtime/handlers/videoconference-handler.ts
+++ b/deno-runtime/handlers/videoconference-handler.ts
@@ -12,13 +12,17 @@ export default async function videoConferenceHandler(call: string, params: unkno
     const logger = AppObjectRegistry.get<Logger>('logger');
 
     if (!provider) {
-        return new JsonRpcError(`Provider ${providerName} not found`, -32000);
+        return JsonRpcError.methodNotFound({
+            message: `Provider ${providerName} not found`,
+        });
     }
 
     const method = provider[methodName as keyof IVideoConfProvider];
 
     if (typeof method !== 'function') {
-        return new JsonRpcError(`Method ${methodName} not found on provider ${providerName}`, -32000);
+        return JsonRpcError.methodNotFound({
+            message: `Method ${methodName} not found on provider ${providerName}`,
+        });
     }
 
     const [videoconf, user, options] = params as Array<unknown>;

--- a/deno-runtime/handlers/videoconference-handler.ts
+++ b/deno-runtime/handlers/videoconference-handler.ts
@@ -12,9 +12,7 @@ export default async function videoConferenceHandler(call: string, params: unkno
     const logger = AppObjectRegistry.get<Logger>('logger');
 
     if (!provider) {
-        return JsonRpcError.methodNotFound({
-            message: `Provider ${providerName} not found`,
-        });
+        return new JsonRpcError(`Provider ${providerName} not found`, -32000);
     }
 
     const method = provider[methodName as keyof IVideoConfProvider];

--- a/src/server/managers/AppVideoConfProvider.ts
+++ b/src/server/managers/AppVideoConfProvider.ts
@@ -89,8 +89,13 @@ export class AppVideoConfProvider {
 
             return result as string | boolean | Array<IBlock> | undefined;
         } catch (e) {
-            if (method === AppMethod._VIDEOCONF_IS_CONFIGURED && e?.code === JSONRPC_METHOD_NOT_FOUND) {
-                return true;
+            if (e?.code === JSONRPC_METHOD_NOT_FOUND) {
+                if (method === AppMethod._VIDEOCONF_IS_CONFIGURED) {
+                    return true;
+                }
+                if (![AppMethod._VIDEOCONF_GENERATE_URL, AppMethod._VIDEOCONF_CUSTOMIZE_URL].includes(method)) {
+                    return undefined;
+                }
             }
 
             // @TODO add error handling

--- a/src/server/managers/AppVideoConfProvider.ts
+++ b/src/server/managers/AppVideoConfProvider.ts
@@ -4,6 +4,7 @@ import type { VideoConference } from '../../definition/videoConferences';
 import type { IVideoConferenceUser } from '../../definition/videoConferences/IVideoConferenceUser';
 import type { IVideoConferenceOptions, IVideoConfProvider, VideoConfData, VideoConfDataExtended } from '../../definition/videoConfProviders';
 import type { ProxiedApp } from '../ProxiedApp';
+import { JSONRPC_METHOD_NOT_FOUND } from '../runtime/deno/AppsEngineDenoRuntime';
 import type { AppLogStorage } from '../storage';
 import type { AppAccessorManager } from './AppAccessorManager';
 
@@ -86,8 +87,12 @@ export class AppVideoConfProvider {
                 params: runContextArgs,
             });
 
-            return result as string;
+            return result as string | boolean | Array<IBlock> | undefined;
         } catch (e) {
+            if (method === AppMethod._VIDEOCONF_IS_CONFIGURED && e?.code === JSONRPC_METHOD_NOT_FOUND) {
+                return true;
+            }
+
             // @TODO add error handling
             console.log(e);
         }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Similarly to how the `checkPre` methods work on the listener manager, we have optional methods in video conf providers that should not block execution if they are not implemented

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
