### PR TITLE
feat: improve package installation and deno caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ jspm_packages
 .npm
 
 .deno
+.deno-cache
 
 # Optional REPL history
 .node_repl_history

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "test:node": "NODE_ENV=test ts-node ./tests/runner.ts",
         "test:deno": "cd deno-runtime && deno task test",
         "gen-doc": "typedoc",
-        "postinstall": "cd deno-runtime && deno cache main.ts && deno test --no-check --no-run"
+        "postinstall": "node scripts/postinstall.js"
     },
     "repository": {
         "type": "git",
@@ -32,10 +32,11 @@
     ],
     "files": [
         "client/**",
-        "server/**",
         "definition/**",
+        "deno-runtime/**",
         "lib/**",
-        "deno-runtime/**"
+        "scripts/**",
+        "server/**"
     ],
     "author": {
         "name": "Rocket.Chat",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,16 @@
+const childProcess = require('child_process');
+const path = require('path');
+
+// Find executable installed by deno-bin
+const executablePath = path.join(require.resolve('deno-bin'), '..', 'bin', 'deno');
+
+const rootPath = path.join(__dirname, '..');
+const DENO_DIR = path.join(rootPath, '.deno-cache');
+
+childProcess.spawnSync(executablePath, ['cache', 'main.ts'], {
+    cwd: path.join(rootPath, 'deno-runtime'),
+    env: {
+        DENO_DIR,
+    },
+    stdio: 'inherit',
+});

--- a/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -128,6 +128,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
             const denoWrapperPath = getDenoWrapperPath();
             // During development, the appsEngineDir is enough to run the deno process
             const appsEngineDir = path.dirname(path.join(denoWrapperPath, '..'));
+            const DENO_DIR = path.join(appsEngineDir, '.deno-cache');
             // When running in production, we're likely inside a node_modules which the Deno
             // process must be able to read in order to include files that use NPM packages
             const parentNodeModulesDir = path.dirname(path.join(appsEngineDir, '..'));
@@ -150,7 +151,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
                 this.appPackage.info.id,
             ];
 
-            this.deno = child_process.spawn(denoExePath, options, { env: null });
+            this.deno = child_process.spawn(denoExePath, options, { env: { DENO_DIR } });
             this.messenger.setReceiver(this.deno);
             this.livenessManager.attach(this.deno);
 

--- a/tsconfig-lint.json
+++ b/tsconfig-lint.json
@@ -3,5 +3,5 @@
     "compilerOptions": {
         "allowJs": true
     },
-    "include": ["./src/**/*", "./tests/**/*", "./gulpfile.js"]
+    "include": ["./scripts/*", "./src/**/*", "./tests/**/*", "./gulpfile.js"]
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
Change installation to force the deno cache directory to be created inside the apps-engine own directory.

This simplifies installation in manual deployments
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
