### PR TITLE
fix: livechat interaction handler is receiving its context data wrapped in a second instance of the context class

### DIFF
--- a/src/server/managers/AppListenerManager.ts
+++ b/src/server/managers/AppListenerManager.ts
@@ -18,8 +18,7 @@ import { UIActionButtonContext } from '../../definition/ui';
 import type { IUIKitResponse, IUIKitSurface, UIKitIncomingInteraction } from '../../definition/uikit';
 import { UIKitIncomingInteractionType } from '../../definition/uikit';
 import { isUIKitIncomingInteractionActionButtonMessageBox } from '../../definition/uikit/IUIKitIncomingInteractionActionButton';
-import type { IUIKitLivechatIncomingInteraction } from '../../definition/uikit/livechat';
-import { UIKitLivechatBlockInteractionContext } from '../../definition/uikit/livechat';
+import type { IUIKitLivechatBlockIncomingInteraction, IUIKitLivechatIncomingInteraction } from '../../definition/uikit/livechat';
 import type {
     IUIKitIncomingInteractionMessageContainer,
     IUIKitIncomingInteractionModalContainer,
@@ -1016,14 +1015,17 @@ export class AppListenerManager {
 
         const app = this.manager.getOneById(appId);
 
-        const interactionContext = ((interactionType: UIKitIncomingInteractionType, interactionData: IUIKitLivechatIncomingInteraction) => {
-            const { actionId, message, visitor, room, triggerId, container } = interactionData;
+        const interactionData = ((
+            interactionType: UIKitIncomingInteractionType,
+            interaction: IUIKitLivechatIncomingInteraction,
+        ): IUIKitLivechatBlockIncomingInteraction => {
+            const { actionId, message, visitor, room, triggerId, container } = interaction;
 
             switch (interactionType) {
                 case UIKitIncomingInteractionType.BLOCK: {
-                    const { value, blockId } = interactionData.payload as { value: string; blockId: string };
+                    const { value, blockId } = interaction.payload as { value: string; blockId: string };
 
-                    return new UIKitLivechatBlockInteractionContext({
+                    return {
                         appId,
                         actionId,
                         blockId,
@@ -1033,12 +1035,12 @@ export class AppListenerManager {
                         value,
                         message,
                         container: container as IUIKitIncomingInteractionModalContainer | IUIKitIncomingInteractionMessageContainer,
-                    });
+                    };
                 }
             }
         })(type, data);
 
-        return app.call(method, interactionContext);
+        return app.call(method, interactionData);
     }
 
     // Livechat


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
When running a livechat uikit interaction, the AppListenerManager wraps the interactionData in an instance of `UIKitLivechatBlockInteractionContext`, but when the deno runtime receives a request for livechat interactions, it also wraps the params in an instance of the same class. This was causing apps to receive this interaction data in the wrong format.

# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
I haven't tested it on an actual app.