### PR TITLE
fix: app subprocess restart not running onEnable lifecycle

### DIFF
--- a/src/server/AppManager.ts
+++ b/src/server/AppManager.ts
@@ -960,6 +960,10 @@ export class AppManager {
             result = false;
 
             await app.setStatus(status, silenceStatus);
+
+            // If some error has happened in initialization, like license or installations invalidation
+            // we need to store this on the DB regardless of what the parameter requests
+            saveToDb = true;
         }
 
         if (saveToDb) {
@@ -1038,6 +1042,10 @@ export class AppManager {
             }
 
             console.error(e);
+
+            // If some error has happened during enabling, like license or installations invalidation
+            // we need to store this on the DB regardless of what the parameter requests
+            saveToDb = true;
         }
 
         if (enable) {

--- a/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -12,7 +12,7 @@ import type { AppBridges } from '../../bridges';
 import type { IParseAppPackageResult } from '../../compiler';
 import { AppConsole, type ILoggerStorageEntry } from '../../logging';
 import type { AppAccessorManager, AppApiManager } from '../../managers';
-import { AppStatus } from '../../../definition/AppStatus';
+import { AppStatus, AppStatusUtils } from '../../../definition/AppStatus';
 import type { AppMethod } from '../../../definition/metadata';
 import { bundleLegacyApp } from './bundler';
 import { ProcessMessenger } from './ProcessMessenger';
@@ -293,6 +293,10 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
 
             await this.sendRequest({ method: 'app:initialize' });
             await this.sendRequest({ method: 'app:setStatus', params: [status] });
+
+            if (AppStatusUtils.isEnabled(this.storageItem.status)) {
+                await this.sendRequest({ method: 'app:onEnable' });
+            }
 
             this.state = 'ready';
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
- Run onEnable on the subprocess restart if the app is enabled
- Ensure disabled status is persisted if an error occurs during app init

Backport from https://github.com/RocketChat/Rocket.Chat/pull/34172
# Why? :thinking:
<!--Additional explanation if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
